### PR TITLE
UI: Remove keys from DataTables and Widgets

### DIFF
--- a/src/exosphere/ui/dashboard.py
+++ b/src/exosphere/ui/dashboard.py
@@ -88,7 +88,7 @@ class DashboardScreen(Screen):
             return
 
         for host in hosts:
-            yield HostWidget(host, id=f"host-{host.name}")
+            yield HostWidget(host)
 
         yield Footer()
 

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -130,9 +130,9 @@ class HostDetailsPanel(Screen):
             self.app.push_screen(ErrorScreen("Host is not initialized."))
             return
 
-        update: Update = [u for u in self.host.updates if u.name == update_name][
-            0
-        ] or None
+        update: Update | None = next(
+            (u for u in self.host.updates if u.name == update_name), None
+        )
 
         if update is None:
             logger.error(f"Update not found for host '{self.host.name}'.")


### PR DESCRIPTION
The naming rules for host.name and the key name are too different, and sanitizing them is too error prone and a one way process. Instead, we'll just let Textual generate its own keys, and use it to select the column
by index given how static our data formats are. This has been done  for Dashboard and Inventory, as well as the HostDetails panel.

Additionally: Guard update selection in host details panel from ever generating index out of bounds as a result of any of this going wrong

Resolves issue: BadIdentifier for hosts with dot #21