### PR TITLE
Massively improve error reporting for discovery

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -25,6 +25,24 @@ Yes! You can specify a custom path for the configuration file by setting the
 See :doc:`configuration` for more details on other environment variables
 you can define to influence or override the configuration.
 
+I get an error with "Private key file is encrypted", what does it mean?
+-----------------------------------------------------------------------
+
+The presence of this error in logs means that authentication failed in some way.
+
+Verify that:
+
+- The server has Public Key Authentication enabled
+- Your SSH agent is running and has the correct key loaded
+- The right user name is being used to connect
+
+The unhelpful error message is unfortunately `Known Issue`_ in the `paramiko` 
+library, which is used internally to handle SSH connections. Whenever
+authentication fails when a SSH agent is used, this is the exception
+that will be raised, regardless of the actual issue.
+
+Exosphere will generally catch this specific error and rewrite the error message
+to be more helpful, but there are a few edge cases where it may be displayed as-is.
 
 My system using `dnf` or `yum` hangs when refreshing
 ----------------------------------------------------
@@ -141,4 +159,4 @@ Compatibility test matrices are unfortunately not a source of happiness.
 .. _UnattendedUpgrades: https://wiki.debian.org/UnattendedUpgrades
 .. _Ansible: https://www.ansible.com/
 .. _RunDeck: https://www.rundeck.com/
-
+.. _Known Issue: https://github.com/paramiko/paramiko/issues/387

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -130,7 +130,7 @@ def run_task_with_progress(
     immediate_error_display: bool = False,
     transient: bool = True,
     progress_args: tuple = (),
-) -> list[tuple[str, str]]:
+) -> list[tuple[str, Exception]]:
     """
     Run a task on selected hosts with progress display.
     This is a nice wrapper around inventory.run_task() that provides
@@ -160,9 +160,9 @@ def run_task_with_progress(
         progress_args: List of renderables to compose the Progress layout
 
     Returns:
-        List of (hostname, error_message) tuples for any failed hosts
+        List of (hostname, exception objects) tuples for any failed hosts
     """
-    errors = []
+    errors: list[tuple[str, Exception]] = []
     short_name = task_name.replace("_", " ").capitalize()
 
     with Progress(transient=transient, *progress_args) as progress:
@@ -179,7 +179,7 @@ def run_task_with_progress(
                     )
 
                 if collect_errors:
-                    errors.append((host.name, str(exc)))
+                    errors.append((host.name, exc))
 
             if display_hosts:
                 progress.console.print(

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -264,7 +264,7 @@ class TestRunTaskWithProgress:
             task_description="Testing task",
         )
 
-        assert result == [("host2", "Test error")]
+        assert result == [("host2", error)]
         assert (
             mock_progress_instance.console.print.call_count == 2
         )  # Two status displays


### PR DESCRIPTION
Host.ping() is now the entry point for reporting, obtaining or otherwise
diagnosing connection issues. It now has an optional bool parameter
(`raise_on_error`) that will allow it to raise HostOfflineError with the
actual exception details, rather than just returning False.

- ui/utils: run_task_with_progress() now returns the Exception object
  when collect_errors is enabled
- Host.ping() can now raise OfflineHostError with full exception
  details when raise_on_error is enabled
- Crappy paramiko PasswordRequiredException is now rewritten with a
  helpful message instead of the generic "Private key file is encrypted"
- Discover command(s) now return helpful error messages for better UX
- Add unit tests for new features and error handling