### PR TITLE
Make path to repl history configurable

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -154,6 +154,7 @@ These options are applied globally, and affect how Exosphere behaves at runtime.
 - :option:`default_sudo_policy`
 - :option:`debug`
 - :option:`log_file`
+- :option:`history_file`
 - :option:`cache_autosave`
 - :option:`cache_autopurge`
 - :option:`cache_file`
@@ -358,6 +359,45 @@ and examples of how to set them in the configuration file.
                 {
                     "options": {
                         "log_file": "/home/alice/exosphere.log"
+                    }
+                }
+
+.. option:: history_file
+
+    A filesystem path to a file where Exosphere will store the REPL history.
+    If not set, Exosphere will use the platform default and name the
+    file ``repl_history``.
+
+    This file is used to persist the command history across executions of Exosphere,
+    allowing you navigate through or search for previously executed commands.
+
+    **Default**: (Platform Default)
+
+    **Example**:
+
+    .. tabs::
+
+        .. group-tab:: YAML
+
+            .. code-block:: yaml
+
+                options:
+                  history_file: /home/alice/.exosphere_history
+
+        .. group-tab:: TOML
+
+            .. code-block:: toml
+
+                [options]
+                history_file = "/home/alice/.exosphere_history"
+
+        .. group-tab:: JSON
+
+            .. code-block:: json
+
+                {
+                    "options": {
+                        "history_file": "/home/alice/.exosphere_history"
                     }
                 }
 

--- a/src/exosphere/config.py
+++ b/src/exosphere/config.py
@@ -42,6 +42,9 @@ class Configuration(dict):
             "log_file": str(
                 fspaths.LOG_DIR / "exosphere.log"
             ),  # Default log file for the application
+            "history_file": str(
+                fspaths.STATE_DIR / "repl_history"
+            ),  # Default history file for the repl
             "cache_autosave": True,  # Automatically save cache to disk after changes
             "cache_autopurge": True,  # Automatically purge hosts removed from inventory
             "cache_file": str(

--- a/src/exosphere/repl.py
+++ b/src/exosphere/repl.py
@@ -20,7 +20,7 @@ from rich.console import Console
 from rich.panel import Panel
 from typer import Context
 
-from exosphere import fspaths
+from exosphere import app_config
 
 logger = logging.getLogger(__name__)
 
@@ -172,12 +172,8 @@ class ExosphereREPL:
                  or InMemoryHistory as fallback
         """
         try:
-            # Ensure state directory exists
-            fspaths.ensure_dirs()
-
-            history_file = fspaths.STATE_DIR / "repl_history"
+            history_file = app_config["options"]["history_file"]
             return FileHistory(str(history_file))
-
         except Exception as e:
             # Fallback to in-memory history if file operations fail
             logger.warning(f"Could not setup persistent history: {e}")


### PR DESCRIPTION

Repl history path can now be configured via:

`history_file` through the configuration options.

Tests have been added to confirm behavior, and documentation has been updated to mention the option.

Default value is the same as previously, from fspaths.

Resolves #31