### PR TITLE
Make Dashboard Responsive, rework empty error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "1.1.0"
+version = "1.2.0.dev1"
 description = "A simple centralized patch reporting tool for unix systems"
 readme = "README.md"
 authors = [

--- a/src/exosphere/ui/dashboard.py
+++ b/src/exosphere/ui/dashboard.py
@@ -96,11 +96,15 @@ class DashboardScreen(Screen):
         inventory = context.inventory
         hosts = getattr(inventory, "hosts", []) or []
 
+        # "No hosts available" box
         if not hosts:
-            yield Label("No hosts available.", classes="empty-message")
+            with VerticalScroll(id="hosts-scroll"):
+                with Container(id="empty-container"):
+                    yield Label("No hosts available.", classes="empty-message")
             yield Footer()
             return
 
+        # Grid container for host widgets
         with VerticalScroll(id="hosts-scroll"):
             with Container(id="hosts-container"):
                 for host in hosts:

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -203,7 +203,9 @@ class InventoryScreen(Screen):
         hosts = getattr(context.inventory, "hosts", []) or []
 
         if not hosts:
-            yield Label("No hosts in inventory.", classes="empty-message")
+            with Vertical():
+                with Container(id="empty-container"):
+                    yield Label("No hosts in inventory.", classes="empty-message")
         else:
             yield DataTable(id="inventory-table")
 

--- a/src/exosphere/ui/style.tcss
+++ b/src/exosphere/ui/style.tcss
@@ -1,8 +1,6 @@
 DashboardScreen {
-    layout: grid;
-    grid-size: 4;
+    layout: vertical;
     layers: below above;
-    align: center middle;
 }
 
 InventoryScreen {
@@ -142,14 +140,26 @@ ErrorScreen {
 }
 
 # Dashboard host widgets
-.host-box {
-    height: 100%;
-    width: auto;
-    text-align: center;
-    border: solid;
-    layer: below;
-    margin-bottom: 0;
+#hosts-scroll {
+    padding: 0;
 }
+
+#hosts-container {
+    layout: grid;
+    grid-size: 4;  /* Default, will update dynamically */
+    grid-gutter: 0 0;
+    height: auto;
+}
+
+.host-box {
+    width: 100%;
+    height: auto;
+    min-height: 8;
+    text-align: center;
+    border: double;
+    layer: below;
+}
+
 .host-box.online {
     border: solid green;
     tint: green 10%;

--- a/src/exosphere/ui/style.tcss
+++ b/src/exosphere/ui/style.tcss
@@ -1,3 +1,4 @@
+# Main Screen Layouts
 DashboardScreen {
     layout: vertical;
     layers: below above;
@@ -13,6 +14,7 @@ HostDetailsPanel {
     align: center middle;
     background: black 60%;
 }
+
 UpdateDetailsPanel {
     layout: vertical;
     align: center middle;
@@ -31,6 +33,43 @@ ErrorScreen {
     background: black 60%;
 }
 
+# Dashboard Components
+#hosts-scroll {
+    padding: 0;
+}
+
+#hosts-container {
+    layout: grid;
+    grid-size: 4;  /* Default, will update dynamically */
+    grid-gutter: 0 0;
+    height: auto;
+}
+
+#empty-container {
+    align: center middle;
+    height: 100%;
+}
+
+.host-box {
+    width: 100%;
+    height: auto;
+    min-height: 8;
+    text-align: center;
+    border: solid;
+    layer: below;
+}
+
+.host-box.online {
+    border: solid green;
+    tint: green 10%;
+}
+
+.host-box.offline {
+    border: solid red;
+    tint: red 10%;
+}
+
+# Detail Panels
 .host-details {
     dock: right;
     width: 45%;
@@ -82,10 +121,13 @@ ErrorScreen {
     text-style: italic;
 }
 
+# Inventory Components
 #inventory-table {
     width: 100%;
     height: 100%;
 }
+
+# Message Boxes
 
 # Empty message box
 .empty-message {
@@ -137,34 +179,4 @@ ErrorScreen {
 
 .error-message Center Button {
     margin-bottom: 1;
-}
-
-# Dashboard host widgets
-#hosts-scroll {
-    padding: 0;
-}
-
-#hosts-container {
-    layout: grid;
-    grid-size: 4;  /* Default, will update dynamically */
-    grid-gutter: 0 0;
-    height: auto;
-}
-
-.host-box {
-    width: 100%;
-    height: auto;
-    min-height: 8;
-    text-align: center;
-    border: double;
-    layer: below;
-}
-
-.host-box.online {
-    border: solid green;
-    tint: green 10%;
-}
-.host-box.offline {
-    border: solid red;
-    tint: red 10%;
 }

--- a/src/exosphere/ui/style.tcss
+++ b/src/exosphere/ui/style.tcss
@@ -51,12 +51,14 @@ ErrorScreen {
 }
 
 .host-box {
+    layout: vertical;
     width: 100%;
-    height: auto;
-    min-height: 8;
+    height: 10;
+    /* min-height: 8; */
     text-align: center;
     border: solid;
     layer: below;
+    padding: 1 1;
 }
 
 .host-box.online {
@@ -66,6 +68,51 @@ ErrorScreen {
 
 .host-box.offline {
     border: solid red;
+    tint: red 10%;
+}
+
+.host-name {
+    text-align: center;
+    width: 100%;
+    height: 1;
+}
+
+.host-version {
+    text-align: center;
+    width: 100%;
+    height: auto;
+    max-height: 2;
+}
+
+.host-description {
+    text-align: center;
+    width: 100%;
+    height: auto;
+    max-height: 2;
+    content-align: center top;
+}
+
+.host-status {
+    dock: bottom;
+    text-align: center;
+    width: 100%;
+    height: 1;
+    content-align: center bottom;
+}
+
+# Host box online state - apply tint to children
+.host-box.online .host-name,
+.host-box.online .host-version,
+.host-box.online .host-description,
+.host-box.online .host-status {
+    tint: green 10%;
+}
+
+# Host box offline state - apply tint to children
+.host-box.offline .host-name,
+.host-box.offline .host-version,
+.host-box.offline .host-description,
+.host-box.offline .host-status {
     tint: red 10%;
 }
 

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -185,26 +185,56 @@ def test_dashboard_compose_with_hosts(mock_context, host_online, host_offline, m
     assert host_widget_calls[1][0][0] == host_offline  # Second call with host_offline
 
 
-def test_dashboard_compose_no_hosts(mock_context):
-    """Test DashboardScreen compose method with no hosts."""
+def test_dashboard_compose_no_hosts(mock_context, mocker):
+    """Test DashboardScreen compose method with no hosts shows empty message."""
     mock_context.inventory.hosts = []
 
     screen = DashboardScreen()
+
+    # Mock Textual widgets to avoid app context issues
+    mock_vertical_scroll = mocker.MagicMock()
+    mock_container = mocker.MagicMock()
+    mock_label = mocker.MagicMock()
+
+    mocker.patch(
+        "exosphere.ui.dashboard.VerticalScroll", return_value=mock_vertical_scroll
+    )
+    mocker.patch("exosphere.ui.dashboard.Container", return_value=mock_container)
+    label_mock = mocker.patch("exosphere.ui.dashboard.Label", return_value=mock_label)
+
     result = list(screen.compose())
 
-    # Should yield Header, empty message Label, and Footer
-    assert len(result) == 3
+    # Should yield Header, VerticalScroll, and Footer
+    assert len(result) >= 3
+
+    # Verify that Label was called with the empty message
+    label_mock.assert_called_with("No hosts available.", classes="empty-message")
 
 
 def test_dashboard_compose_no_inventory(mocker):
-    """Test DashboardScreen compose method with no inventory."""
+    """Test DashboardScreen compose method with no inventory shows empty message."""
     mocker.patch("exosphere.ui.dashboard.context.inventory", None)
 
     screen = DashboardScreen()
+
+    # Mock Textual widgets to avoid app context issues
+    mock_vertical_scroll = mocker.MagicMock()
+    mock_container = mocker.MagicMock()
+    mock_label = mocker.MagicMock()
+
+    mocker.patch(
+        "exosphere.ui.dashboard.VerticalScroll", return_value=mock_vertical_scroll
+    )
+    mocker.patch("exosphere.ui.dashboard.Container", return_value=mock_container)
+    label_mock = mocker.patch("exosphere.ui.dashboard.Label", return_value=mock_label)
+
     result = list(screen.compose())
 
-    # Should yield Header, empty message Label, and Footer
-    assert len(result) == 3
+    # Should yield Header, VerticalScroll, and Footer
+    assert len(result) >= 3
+
+    # Verify that Label was called with the empty message
+    label_mock.assert_called_with("No hosts available.", classes="empty-message")
 
 
 def test_dashboard_refresh_hosts_with_task(mocker, mock_context):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "sys_platform != 'win32'",
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "1.1.0"
+version = "1.2.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
This makes the dashboard responsive, within reason. Overflow will scroll.

Dashboard will also correctly change its amount of columns (min 2, max 8) when the terminal is resized. Resolves #9 

HostWidget tiles are now using a vertical layout within themselves, and each piece of information is now its own label, allowing for more flexible syling.

Additionally: "no host available" messages when the inventory is empty are now correctly centered on both the dashboard and inventory screen, fixing #12 