### PR TITLE
Disallow username@host form in config ip field, add validations

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -863,6 +863,11 @@ Below is the detailed list of all available host options and their defaults.
     It is recommended to use a fully qualified domain name or an IP address
     to avoid issues with DNS resolution.
 
+    .. attention::
+
+        The **ip** field must not contain the ``@`` character. To specify a username,
+        use the :option:`username` field instead.
+
     **Mandatory**: Yes
 
     **Example**:

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -2,6 +2,7 @@ quickstart
 toml
 unicity
 dicts
+dev
 tomllib
 dataclass
 dataclasses

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -432,6 +432,38 @@ class TestConfiguration:
                 }
             )
 
+    @pytest.mark.parametrize(
+        "hosts_data,expected_error_match",
+        [
+            # Missing required fields
+            (
+                [{"ip": "127.0.0.4"}],
+                "missing required 'name' field",
+            ),
+            (
+                [{"name": "host4"}],
+                "missing required 'ip' field",
+            ),
+            # Invalid characters in fields
+            (
+                [{"name": "host1", "ip": "user@127.0.0.1"}],
+                "invalid hostname or ip.*'@' character is not allowed",
+            ),
+        ],
+        ids=["missing_name", "missing_ip", "at_in_ip"],
+    )
+    def test_update_from_mapping_validation_errors(
+        self, hosts_data, expected_error_match
+    ):
+        """
+        Ensure that the configuration object raises appropriate ValueError
+        for various validation failures in the host section.
+        """
+        config = Configuration()
+
+        with pytest.raises(ValueError, match=expected_error_match):
+            config.update_from_mapping({"hosts": hosts_data})
+
     def test_update_from_env(self, mocker, monkeypatch):
         """
         Ensure that the Configuration object can be updated


### PR DESCRIPTION
We now ban the @ character from the ip field since the 'user@host' form is not explicitly supported across the codebase, just the library. This can (and will) result in unexpected behavior, so we now simply bail and inform the user that they should use the the 'username' field to specify this at all.

The name and ip field must be present, as per the documentation, but this is now made explicit as to give a better exception message instead of letting whatever issue omitting the fields generate propagate up.

Documentation has been updated to point this out.

Indirectly pointed out by #50 