### PR TITLE
redhat provider: Prevent duplicates in updates

### DIFF
--- a/src/exosphere/providers/redhat.py
+++ b/src/exosphere/providers/redhat.py
@@ -122,6 +122,15 @@ class Dnf(PkgManager):
         )
 
         for name, version, source in parsed_tuples:
+            # If update was provided by security or kernel checks, skip it here
+            # Whether it shows up in both lists depends on configuration and
+            # this varies from specific flavor to flavor.
+            if name in [u.name for u in updates]:
+                self.logger.debug(
+                    "Update for %s is already in the list, skipping", name
+                )
+                continue
+
             is_security = name in self.security_updates
 
             current_version = installed_versions.get(name, None)


### PR DESCRIPTION
In some configurations (this varies from flavor to flavor), updates can end up being obtained by any or all of security, kernel and general updates. The interface does not have a convenient way of doing exclusions in a way that retains coverage equally on all flavors, so we simply check whether or not updates are already found before creating the objects.
This is independent of version clobbering.