### PR TITLE
Redhat provider: return current version for kernel

### DIFF
--- a/src/exosphere/providers/redhat.py
+++ b/src/exosphere/providers/redhat.py
@@ -237,7 +237,7 @@ class Dnf(PkgManager):
 
             return Update(
                 name=latest_name,
-                current_version=None,
+                current_version=installed_versions[-1] if installed_versions else None,
                 new_version=latest_version,
                 source=latest_source,
                 security=is_security,


### PR DESCRIPTION
I changed my mind and instead of following dnf's inane rule about slotted packages not being upgrades, we'll follow the principle of least surprise and present the package as an upgrade, because the users (myself included) will not care. Additionally, we already do this for supplementary kernel packages such as kernel-core, kernel-modules, kernel-tools etc, so consistency seems like a good idea.