### PR TITLE
Allow unsupported unix-like systems to be added to the inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ or see [the documentation](https://exosphere.readthedocs.io/en/stable/) to get s
 - Consistent view of information across different platforms and package managers
 - See everything in one spot, at a glance, without complex automation or enterprise
   solutions
+- Does not require Python (or anything else) to be installed on remote systems.
 
 ## Compatibility
 
@@ -37,6 +38,15 @@ Supported platforms for remote hosts include:
 - Debian/Ubuntu and derivatives (using APT)
 - Red Hat/CentOS and derivatives (using YUM/DNF)
 - FreeBSD (using pkg)
+
+Unsupported platform with with SSH connectivity checks only:
+
+- Other Linux distributions (e.g., Arch Linux, Gentoo, NixOS, etc.)
+- Other BSD systems (e.g., OpenBSD, NetBSD)
+- Other Unix-like systems (e.g., Solaris, AIX, IRIX, Mac OS)
+
+Exosphere **does not support** other platforms where SSH is available.
+This includes network equipment with proprietary operating systems, etc.
 
 ## Documentation
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -173,9 +173,17 @@ by running:
 This will attempt to SSH into each host and check if it is online. If a host
 is not reachable, it will be marked as offline and an error will be printed.
 
+This is **not** an ICMP ping, but rather a full SSH connectivity check. 
+It will only return "Online" if the host can be connected to successfully,
+and a trivial test command can be executed.
+
 It can be a good way of validating connectivity to hosts. If ping returns "Online"
 for all hosts, you can be certain your SSH connectivity is working within the
 context of Exosphere.
+
+This is by design to avoid scenarios where a host is reachable but not fully
+operational, for instance mid-startup or mid-shutdown, which would cause
+subsequent queries or operations to fail.
 
 Hosts marked as Offline will be skipped in most operations such as ``refresh``
 for performance reasons. You can invoke Ping to refresh this status at any time.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -53,7 +53,13 @@ it will be marked as such, and left available for Online checks. You will not be
 able to perform refresh or repo sync operations on them, and display panels will
 omit update information for them.
 
-This can be done by running:
+If a host is present in the inventory, not supported by Exosphere and also
+fails discovery due to not being a Unix-like operating system, it will return
+an explicit error, and should be removed for smooth operation.
+
+For more details, see the :doc:`supportedos` page.
+
+Inventory discovery can be done by running:
 
 .. code-block:: exosphere
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -48,6 +48,11 @@ operating system, flavor, version and package manager it is using.
 It will then assign the appropriate provider to that host, which will allow
 Exosphere to query and refresh its package update status from here on.
 
+If a host is present in the inventory, but not currently supported by Exosphere,
+it will be marked as such, and left available for Online checks. You will not be
+able to perform refresh or repo sync operations on them, and display panels will
+omit update information for them.
+
 This can be done by running:
 
 .. code-block:: exosphere

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -35,8 +35,8 @@ Why does ping report Offline when the system is reachable?
 
 The ``ping`` checks in exosphere aren't ICMP ping, but SSH pings.
 They will only return an Online status if the remote system can be
-connected to successfully, over SSH, and a simple echo command can be
-executed.
+connected to successfully, over SSH, and a simple POSIX test command 
+can be executed. (``/bin/true`` or shell built-in equivalent)
 
 As such, scenarios that can cause an Offline status include:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -19,11 +19,16 @@ already exists, such as `UnattendedUpgrades`_, `Ansible`_, `RunDeck`_, etc.
 I really like the dashboard. Can I still use it if my systems are unsupported?
 ------------------------------------------------------------------------------
 
-Yes. If your remote operating system is not supported, Exosphere will allow
+Yes, as long as it the remote system is a Unix-like operating system.
+
+In this case, if your remote operating system is not supported, Exosphere will allow
 you to use the dashboard and online checks (ping command, etc) just fine.
 
 You won't be able to perform refresh or sync operation on them, and the update
 counts will be disabled, but this part will remain functional.
+
+If the system in question is not a Unix-like operating system, it will not
+be discoverable at all, and should not be added to the inventory.
 
 Why does ping report Offline when the system is reachable?
 ----------------------------------------------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -25,6 +25,31 @@ you to use the dashboard and online checks (ping command, etc) just fine.
 You won't be able to perform refresh or sync operation on them, and the update
 counts will be disabled, but this part will remain functional.
 
+Why does ping report Offline when the system is reachable?
+----------------------------------------------------------
+
+The ``ping`` checks in exosphere aren't ICMP ping, but SSH pings.
+They will only return an Online status if the remote system can be
+connected to successfully, over SSH, and a simple echo command can be
+executed.
+
+As such, scenarios that can cause an Offline status include:
+
+* SSH Authentication Failure (bad username, invalid credentials)
+* Timeouts and Connectivity Errors
+* Failure to execute to supremely basic ping test command
+
+We consider "Online" to mean "the system is up and ready to process further queries",
+instead of just "the system is reachable over the network".
+
+This is by design, and aims to avoid scenarios where the system is reachable,
+but is currently shutting down, or has not finished booting.
+
+Generally, if the host shows up as Offline, you would not be able to
+perform any of the other operations on it anyways.
+
+You can re-run the ``discovery`` command to find out what the issue is and
+correct it, if you are getting this during initial setup.
 
 Can I specify a custom path for the configuration file?
 -------------------------------------------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -16,6 +16,16 @@ make informed decisions about what needs patching, and when.
 This functionality is not planned, and left to frankly better tooling that
 already exists, such as `UnattendedUpgrades`_, `Ansible`_, `RunDeck`_, etc.
 
+I really like the dashboard. Can I still use it if my systems are unsupported?
+------------------------------------------------------------------------------
+
+Yes. If your remote operating system is not supported, Exosphere will allow
+you to use the dashboard and online checks (ping command, etc) just fine.
+
+You won't be able to perform refresh or sync operation on them, and the update
+counts will be disabled, but this part will remain functional.
+
+
 Can I specify a custom path for the configuration file?
 -------------------------------------------------------
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -41,3 +41,4 @@ subcommands
 keybind
 keybinds
 tcp
+solaris

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -2,16 +2,34 @@ Supported Remote Platforms
 ==========================
 
 While Exosphere itself is generally as platform agnostic as possible, it is limited
-in what operating systems and platforms it can manage and query.
+in what operating systems and platforms it can manage and query. This is broadly
+limited to Unix-like platforms, including Linux and BSD variants.
+
+There are two tiers of effective support in Exosphere.
+
+1. **Full Support**: Allows connectivity checks, update and patch reporting,
+   and detailed host information gathering.
+
+2. **Limited Support**: For unsupported platforms that are still Unix-like,
+   Exosphere is limited to basic SSH connectivity checks and presence in
+   the dashboard. 
 
 Platform support for Patches and Updates are implemented via an extensible
 provider system, which allows for new platforms to be added in the future.
 
-**If your remote operating system is not supported**, you can still use Exosphere for
-the basic SSH ping connectivity checks and Dashboard. They will show up in the
-inventory, but no patch and update reporting features will be available for them.
+**If your remote operating system does not have a provider**, you can still use
+Exosphere for the basic SSH ping connectivity checks and Dashboard. They will
+show up in the inventory, but no patch and update reporting features will be available,
+*as long as it is a unix-like operating system and obeys basic POSIX standards.*
 
-Currently, Exosphere can manage and query the following platforms:
+Unfortunately, this excludes exotic things such as Windows, routers with SSH enabled
+but proprietary, non-Unix-like operating systems, etc. Discovery will not work at all
+for these systems, and they should probably not be added to the inventory.
+
+Compatibility List
+------------------
+
+✅ Exosphere **fully supports** the following platforms:
 
 **Debian-based Systems**
   - Debian (all versions)
@@ -26,11 +44,26 @@ Currently, Exosphere can manage and query the following platforms:
   - *Package Managers*: ``yum`` (RHEL/CentOS 7 and earlier) or ``dnf`` (modern systems)
 
 **BSD Systems**
-  - FreeBSD (all supported versions)
+  - FreeBSD (all supported versions and minor variants)
   - *Package Manager*: ``pkg``
 
+☑️ Exosphere has **limited support** for the following platforms:
+
+- Other Linux distributions (e.g., Arch Linux, Gentoo, NixOS, etc.)
+- Other BSD systems (e.g., OpenBSD, NetBSD)
+- Other Unix-like systems (e.g., Solaris, AIX, IRIX, Mac OS)
+
+The bar for entry is fairly low to fit this description, as long as it can be connected
+to via SSH and returns something useful via ``uname -s``, it will work here.
+
+❌ Exosphere explicitly **does not support** the following platforms:
+
+- Windows (all versions, but WSL over SSH is supported)
+- Network Equipment with proprietary operating systems (e.g., Cisco IOS, Juniper JunOS)
+- Other non-Unix-like operating systems that support SSH
+
 .. tip::
-   If your preferred platform is not listed, contributions to add new providers 
+   If your preferred platform is not supported, contributions to add new providers 
    are welcome! See the developer documentation for details on implementing new providers.
 
 Common Prerequisites

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -7,6 +7,10 @@ in what operating systems and platforms it can manage and query.
 Platform support for Patches and Updates are implemented via an extensible
 provider system, which allows for new platforms to be added in the future.
 
+**If your remote operating system is not supported**, you can still use Exosphere for
+the basic SSH ping connectivity checks and Dashboard. They will show up in the
+inventory, but no patch and update reporting features will be available for them.
+
 Currently, Exosphere can manage and query the following platforms:
 
 **Debian-based Systems**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "1.2.1.dev1"
+version = "1.3.0.dev0"
 description = "A simple centralized patch reporting tool for unix systems"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "exosphere-cli"
 version = "1.3.0.dev0"
-description = "A simple centralized patch reporting tool for unix systems"
+description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [
     { name = "Alexandre Gauthier", email = "alex@underwares.org" }

--- a/src/exosphere/commands/host.py
+++ b/src/exosphere/commands/host.py
@@ -72,7 +72,7 @@ def _make_host_panel_content(host: Host) -> str:
     )
 
     # Show specific content for supported and unsupported hosts
-    if getattr(host, "supported", True):
+    if host.supported:
         content += _make_supported_host_content(host)
     else:
         content += _make_unsupported_host_content(host)
@@ -181,16 +181,15 @@ def show(
         )
     )
 
-    # Handle unsupported hosts
-    if not getattr(host, "supported", True):
-        if include_updates:
-            console.print(
-                "[yellow]Update info is not available for unsupported hosts.[/yellow]"
-            )
-        raise typer.Exit(code=0)
-
     # Exit early if updates not requested
     if not include_updates:
+        raise typer.Exit(code=0)
+
+    # Handle unsupported hosts
+    if not host.supported:
+        console.print(
+            "[yellow]Update info is not available for unsupported hosts.[/yellow]"
+        )
         raise typer.Exit(code=0)
 
     # Display updates table

--- a/src/exosphere/commands/host.py
+++ b/src/exosphere/commands/host.py
@@ -88,7 +88,13 @@ def show(
             f"[bold]Host Name:[/bold] {host.name}\n"
             f"[bold]IP Address:[/bold] {host.ip}\n"
             f"[bold]Port:[/bold] {host.port}\n"
-            f"[bold]Online Status:[/bold] {'[bold green]Online[/bold green]' if host.online else '[red]Offline[/red]'}\n"
+            f"[bold]Online Status:[/bold] {'[bold green]Online[/bold green]' if host.online else '[red]Offline[/red]'}"
+            + (
+                " ([yellow]Unsupported OS[/yellow])"
+                if host.online and not getattr(host, "supported", True)
+                else ""
+            )
+            + "\n"
             "\n"
             f"[bold]Last Refreshed:[/bold] {last_refresh}\n"
             f"[bold]Stale:[/bold] {'[yellow]Yes[/yellow]' if host.is_stale else 'No'}\n"

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -411,7 +411,10 @@ def clear(
     confirm: Annotated[
         bool,
         typer.Option(
-            "--force", "-f", help="Do not prompt for confirmation", prompt=True
+            "--force",
+            "-f",
+            help="Do not prompt for confirmation",
+            prompt="Clear inventory state?",
         ),
     ],
 ) -> None:

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -319,26 +319,27 @@ def status(
         stale_suffix = " [dim]*[/dim]" if host.is_stale else ""
         unknown_status = "[dim](unknown)[/dim]"
         unsupported_status = "[dim](unsupported)[/dim]"
+        empty_placeholder = "[dim]—[/dim]"
 
-        # Prepare the table row data
-        updates = f"{len(host.updates)}{stale_suffix}"
+        # Prepare table row data
+        if getattr(host, "supported", True):
+            updates = f"{len(host.updates)}{stale_suffix}"
 
-        sec_count = len(host.security_updates) if host.security_updates else 0
-        security_updates = (
-            f"[red]{sec_count}[/red]" if sec_count > 0 else str(sec_count)
-        ) + stale_suffix
+            sec_count = len(host.security_updates) if host.security_updates else 0
+            security_updates = (
+                f"[red]{sec_count}[/red]" if sec_count > 0 else str(sec_count)
+            ) + stale_suffix
+        else:
+            # Do not show update counts for unsupported hosts
+            updates = empty_placeholder
+            security_updates = empty_placeholder
 
         online_status = (
             "[bold green]Online[/bold green]" if host.online else "[red]Offline[/red]"
         )
 
-        # Do not show update counts for unsupported hosts
-        if not getattr(host, "supported", True):
-            updates = "[dim]—[/dim]"
-            security_updates = "[dim]—[/dim]"
-
         # Handle platform info display with unsupported status
-        def get_platform_info(value, attr_name):
+        def get_platform_info(value):
             if value:
                 return value
             elif host.online and not getattr(host, "supported", True):
@@ -349,9 +350,9 @@ def status(
         # Construct table
         table.add_row(
             host.name,
-            get_platform_info(host.os, "os"),
-            get_platform_info(host.flavor, "flavor"),
-            get_platform_info(host.version, "version"),
+            get_platform_info(host.os),
+            get_platform_info(host.flavor),
+            get_platform_info(host.version),
             updates,
             security_updates,
             online_status,

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -332,6 +332,11 @@ def status(
             "[bold green]Online[/bold green]" if host.online else "[red]Offline[/red]"
         )
 
+        # Do not show update counts for unsupported hosts
+        if not getattr(host, "supported", True):
+            updates = "[dim]—[/dim]"
+            security_updates = "[dim]—[/dim]"
+
         # Handle platform info display with unsupported status
         def get_platform_info(value, attr_name):
             if value:

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -318,6 +318,7 @@ def status(
         # Prepare some rendering data for suffixes and placeholders
         stale_suffix = " [dim]*[/dim]" if host.is_stale else ""
         unknown_status = "[dim](unknown)[/dim]"
+        unsupported_status = "[dim](Unsupported)[/dim]"
 
         # Prepare the table row data
         updates = f"{len(host.updates)}{stale_suffix}"
@@ -331,12 +332,22 @@ def status(
             "[bold green]Online[/bold green]" if host.online else "[red]Offline[/red]"
         )
 
+        # Handle platform info display with unsupported status
+        def get_platform_info(value, attr_name):
+            if value:
+                return value
+            elif host.online and not getattr(host, "supported", True):
+                # Show (Unsupported) for online but unsupported hosts
+                return unsupported_status
+            else:
+                return unknown_status
+
         # Construct table
         table.add_row(
             host.name,
-            host.os or unknown_status,
-            host.flavor or unknown_status,
-            host.version or unknown_status,
+            get_platform_info(host.os, "os"),
+            get_platform_info(host.flavor, "flavor"),
+            get_platform_info(host.version, "version"),
             updates,
             security_updates,
             online_status,

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -322,7 +322,7 @@ def status(
         empty_placeholder = "[dim]—[/dim]"
 
         # Prepare table row data
-        if getattr(host, "supported", True):
+        if host.supported:
             updates = f"{len(host.updates)}{stale_suffix}"
 
             sec_count = len(host.security_updates) if host.security_updates else 0
@@ -342,7 +342,7 @@ def status(
         def get_platform_info(value):
             if value:
                 return value
-            elif host.online and not getattr(host, "supported", True):
+            elif host.online and not host.supported:
                 return unsupported_status
             else:
                 return unknown_status

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -318,7 +318,7 @@ def status(
         # Prepare some rendering data for suffixes and placeholders
         stale_suffix = " [dim]*[/dim]" if host.is_stale else ""
         unknown_status = "[dim](unknown)[/dim]"
-        unsupported_status = "[dim](Unsupported)[/dim]"
+        unsupported_status = "[dim](unsupported)[/dim]"
 
         # Prepare the table row data
         updates = f"{len(host.updates)}{stale_suffix}"
@@ -337,7 +337,6 @@ def status(
             if value:
                 return value
             elif host.online and not getattr(host, "supported", True):
-                # Show (Unsupported) for online but unsupported hosts
                 return unsupported_status
             else:
                 return unknown_status

--- a/src/exosphere/commands/sudo.py
+++ b/src/exosphere/commands/sudo.py
@@ -170,6 +170,11 @@ def check(
         err_console.print(f"[red]Host '{host}' not found in inventory![/red]")
         raise typer.Exit(1)
 
+    # We cannot check unsupported hosts, as they don't have providers.
+    if not getattr(target_host, "supported", True):
+        err_console.print(f"[red]Host '{host}' is not running a supported OS.[/red]")
+        raise typer.Exit(1)
+
     # Collect sudo policies
     host_policy: SudoPolicy = target_host.sudo_policy
     policy_is_local = host_policy != global_policy
@@ -352,6 +357,13 @@ def generate(
         target_host = inventory.get_host(host)
         if not target_host:
             err_console.print(f"[red]Host '{host}' not found in inventory![/red]")
+            raise typer.Exit(1)
+
+        # We can't generate anything for unsupported hosts.
+        if not getattr(target_host, "supported", True):
+            err_console.print(
+                f"[red]Host '{host}' is not running a supported OS.[/red]"
+            )
             raise typer.Exit(1)
 
         target_provider_name = target_host.package_manager

--- a/src/exosphere/commands/sudo.py
+++ b/src/exosphere/commands/sudo.py
@@ -171,7 +171,7 @@ def check(
         raise typer.Exit(1)
 
     # We cannot check unsupported hosts, as they don't have providers.
-    if not getattr(target_host, "supported", True):
+    if not target_host.supported:
         err_console.print(f"[red]Host '{host}' is not running a supported OS.[/red]")
         raise typer.Exit(1)
 
@@ -360,7 +360,7 @@ def generate(
             raise typer.Exit(1)
 
         # We can't generate anything for unsupported hosts.
-        if not getattr(target_host, "supported", True):
+        if not target_host.supported:
             err_console.print(
                 f"[red]Host '{host}' is not running a supported OS.[/red]"
             )

--- a/src/exosphere/data.py
+++ b/src/exosphere/data.py
@@ -20,9 +20,10 @@ class HostInfo:
     """
 
     os: str
-    version: str
-    flavor: str
-    package_manager: str
+    version: str | None
+    flavor: str | None
+    package_manager: str | None
+    is_supported: bool
 
 
 @dataclass(frozen=True)

--- a/src/exosphere/errors.py
+++ b/src/exosphere/errors.py
@@ -5,6 +5,17 @@ This module defines custom exception types used throughout the
 Exosphere application.
 """
 
+# Standard authentication error message for better UX
+# This is intended to be displayed whenever Paramiko raises
+# PasswordRequiredException, which is nearly always, and has the
+# most inscrutable error message known to man.
+AUTH_FAILURE_MESSAGE = (
+    "Auth Failure. "
+    "Verify that keypair authentication is enabled on the server, "
+    "that your agent is running with the correct keys loaded, "
+    "and that your username is correct for the host."
+)
+
 
 class DataRefreshError(Exception):
     """Exception raised for errors encountered during data refresh."""

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -356,6 +356,15 @@ class Host:
         if not self.online:
             raise OfflineHostError(f"Host {self.name} is offline or unreachable.")
 
+        # If the platform is not supported, skip operation
+        if not self.supported:
+            self.logger.warning(
+                "Host %s uses an unsupported OS/platform. "
+                "Repository sync is not available.",
+                self.name,
+            )
+            return
+
         # If the concrete package manager provider is not set,
         # refuse the temptation to guess or force a sync, and throw
         # an exception instead. Caller can deal with it.
@@ -390,6 +399,15 @@ class Host:
         """
         if not self.online:
             raise OfflineHostError(f"Host {self.name} is offline.")
+
+        # If the platform is not supported, skip operation
+        if not self.supported:
+            self.logger.warning(
+                "Host %s uses an unsupported OS/platform. "
+                "Update refresh is not available.",
+                self.name,
+            )
+            return
 
         if self._pkginst is None:
             self.logger.error("Package manager implementation unavailable!")

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -497,10 +497,17 @@ class Host:
         return self.online
 
     def __str__(self):
+        if self.online and self.supported:
+            status = "Online"
+        elif self.online and not self.supported:
+            status = "Online (Unsupported)"
+        else:
+            status = "Offline"
+
         return (
             f"{self.name} ({self.ip}:{self.port}) "
             f"[{self.os}, {self.version}, {self.flavor}, "
-            f"{self.package_manager}], {'Online' if self.online else 'Offline'}"
+            f"{self.package_manager}], {status}"
         )
 
     def __repr__(self):

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -139,6 +139,10 @@ class Host:
 
         self.__dict__.update(state)
 
+        # Ensure supported member is set for backward compatibility
+        if not hasattr(self, "supported"):
+            self.supported = True
+
         # Reset unserializables
         self.logger = logging.getLogger(__name__)
         self._connection = None
@@ -175,10 +179,6 @@ class Host:
                         "Unable to de-serialize Host object state: "
                         f"Missing required parameter '{name}'"
                     )
-
-        # Ensure supported field is set for backward compatibility
-        if not hasattr(self, "supported"):
-            self.supported = True
 
     @property
     def connection(self) -> Connection:

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -142,7 +142,7 @@ class Host:
         # Reset unserializables
         self.logger = logging.getLogger(__name__)
         self._connection = None
-        if "package_manager" in state:
+        if "package_manager" in state and state["supported"]:
             self._pkginst = PkgManagerFactory.create(state["package_manager"])
 
         # Ensure all parameters with defaults are properly set

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -176,6 +176,10 @@ class Host:
                         f"Missing required parameter '{name}'"
                     )
 
+        # Ensure supported field is set for backward compatibility
+        if not hasattr(self, "supported"):
+            self.supported = True
+
     @property
     def connection(self) -> Connection:
         """

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -142,7 +142,7 @@ class Host:
         # Reset unserializables
         self.logger = logging.getLogger(__name__)
         self._connection = None
-        if "package_manager" in state and state["supported"]:
+        if "package_manager" in state and state.get("supported", False):
             self._pkginst = PkgManagerFactory.create(state["package_manager"])
 
         # Ensure all parameters with defaults are properly set

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -94,6 +94,11 @@ class Host:
         # until first discovery.
         self.online: bool = False
 
+        # Default supported state is true
+        # All hosts are assumed supported until
+        # discover reports otherwise.
+        self.supported: bool = True
+
         # Internal state of host
         self.os: str | None = None
         self.version: str | None = None

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -255,6 +255,10 @@ class Host:
 
         :return: True if the host is stale, False otherwise
         """
+        # Unsupported hosts cannot be stale by definition
+        if not self.supported:
+            return False
+
         if self.last_refresh is None:
             return True
 

--- a/src/exosphere/ui/dashboard.py
+++ b/src/exosphere/ui/dashboard.py
@@ -44,7 +44,7 @@ class HostWidget(Widget):
             # Version info
             if not self.host.flavor or not self.host.version:
                 # Differenciate between unsupported and undiscovered
-                if self.host.online and not getattr(self.host, "supported", True):
+                if self.host.online and not self.host.supported:
                     version_text = f"[dim]{self.host.os} (unsupported)[/dim]"
                 else:
                     version_text = "[dim](Undiscovered)[/dim]"
@@ -85,7 +85,7 @@ class HostWidget(Widget):
         # Update version info, with unsupported/undiscovered status
         version_label = self.query_one(".host-version", Label)
         if not self.host.flavor or not self.host.version:
-            if self.host.online and not getattr(self.host, "supported", True):
+            if self.host.online and not self.host.supported:
                 version_text = f"[dim]{self.host.os} (unsupported)[/dim]"
             else:
                 version_text = "[dim](Undiscovered)[/dim]"

--- a/src/exosphere/ui/dashboard.py
+++ b/src/exosphere/ui/dashboard.py
@@ -45,7 +45,7 @@ class HostWidget(Widget):
             if not self.host.flavor or not self.host.version:
                 # Differenciate between unsupported and undiscovered
                 if self.host.online and not getattr(self.host, "supported", True):
-                    version_text = "[dim](Unsupported)[/dim]"
+                    version_text = f"[dim]{self.host.os} (unsupported)[/dim]"
                 else:
                     version_text = "[dim](Undiscovered)[/dim]"
             else:
@@ -86,7 +86,7 @@ class HostWidget(Widget):
         version_label = self.query_one(".host-version", Label)
         if not self.host.flavor or not self.host.version:
             if self.host.online and not getattr(self.host, "supported", True):
-                version_text = "[dim](Unsupported)[/dim]"
+                version_text = f"[dim]{self.host.os} (unsupported)[/dim]"
             else:
                 version_text = "[dim](Undiscovered)[/dim]"
         else:

--- a/src/exosphere/ui/dashboard.py
+++ b/src/exosphere/ui/dashboard.py
@@ -43,7 +43,11 @@ class HostWidget(Widget):
 
             # Version info
             if not self.host.flavor or not self.host.version:
-                version_text = "[dim](Undiscovered)[/dim]"
+                # Differenciate between unsupported and undiscovered
+                if self.host.online and not getattr(self.host, "supported", True):
+                    version_text = "[dim](Unsupported)[/dim]"
+                else:
+                    version_text = "[dim](Undiscovered)[/dim]"
             else:
                 version_text = f"[dim]{self.host.flavor} {self.host.version}[/dim]"
             yield Label(version_text, classes="host-version")
@@ -78,10 +82,13 @@ class HostWidget(Widget):
         )
         status_label.update(status_text)
 
-        # Update version info, in case host is now discovered
+        # Update version info, with unsupported/undiscovered status
         version_label = self.query_one(".host-version", Label)
         if not self.host.flavor or not self.host.version:
-            version_text = "[dim](Undiscovered)[/dim]"
+            if self.host.online and not getattr(self.host, "supported", True):
+                version_text = "[dim](Unsupported)[/dim]"
+            else:
+                version_text = "[dim](Undiscovered)[/dim]"
         else:
             version_text = f"[dim]{self.host.flavor} {self.host.version}[/dim]"
         version_label.update(version_text)

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -363,7 +363,7 @@ class InventoryScreen(Screen):
             updates = str(upd_count)
 
             # Do not show updates for unsupported hosts
-            if not getattr(host, "supported", True):
+            if not host.supported:
                 security_updates = "[dim]—[/dim]"
                 updates = "[dim]—[/dim]"
 

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -41,7 +41,9 @@ class HostDetailsPanel(Screen):
 
         platform: str
 
-        if not self.host.flavor or not self.host.version:
+        if not self.host.supported:
+            platform = f"{self.host.os} [yellow](Unsupported)[/yellow]"
+        elif not self.host.flavor or not self.host.version:
             platform = "(Undiscovered)"
         elif self.host.os == self.host.flavor:
             platform = f"{self.host.os} {self.host.version}"
@@ -331,9 +333,12 @@ class InventoryScreen(Screen):
     def _populate_table(self, table: DataTable, hosts: list[Host]):
         """Populate given table with host data"""
 
-        def maybe_undiscovered(value: str | None) -> str:
+        def maybe_unknown(value: str | None, supported: bool = False) -> str:
             """Format as undiscovered if None or empty"""
-            return value if value else "[dim](undiscovered)[/dim]"
+            state = (
+                "[dim](undiscovered)[/dim]" if supported else "[dim](unsupported)[/dim]"
+            )
+            return value if value else state
 
         for host in hosts:
             sec_count: int = len(host.security_updates) if host.security_updates else 0
@@ -354,9 +359,9 @@ class InventoryScreen(Screen):
 
             table.add_row(
                 host.name,
-                maybe_undiscovered(host.os),
-                maybe_undiscovered(host.flavor),
-                maybe_undiscovered(host.version),
+                maybe_unknown(host.os, host.supported),
+                maybe_unknown(host.flavor, host.supported),
+                maybe_unknown(host.version, host.supported),
                 updates,
                 security_updates,
                 status_str,

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -171,7 +171,7 @@ class TestShowCommand:
 
         assert result.exit_code == 1
         assert (
-            "Warning: --security-only option is only valid with --updates"
+            "Error: --security-only option is only valid with --updates"
             in result.output
         )
 

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -30,6 +30,7 @@ def mock_host(mocker):
     instance.port = 22
     instance.description = "Mock Host"
     instance.online = True
+    instance.supported = True
     instance.is_stale = False
     instance.flavor = "ubuntu"
     instance.os = "ubuntu"

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -205,7 +205,9 @@ class TestShowCommand:
         assert result.exit_code == 0
         assert "irix (Unsupported OS)" in result.output
 
-    def test_unsupported_host_no_updates_display(self, mock_host, patch_context_inventory):
+    def test_unsupported_host_no_updates_display(
+        self, mock_host, patch_context_inventory
+    ):
         """
         Test that updates are not shown for unsupported hosts.
         """

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -188,6 +188,37 @@ class TestShowCommand:
         assert result.exit_code == 0
         assert "No updates available for this host." in result.output
 
+    def test_unsupported_host_display(self, mock_host, patch_context_inventory):
+        """
+        Test host show with an unsupported host.
+        """
+        # Mark host as unsupported but online
+        mock_host.supported = False
+        mock_host.online = True
+        mock_host.os = "irix"
+        mock_host.flavor = None
+        mock_host.version = None
+        mock_host.package_manager = None
+
+        result = runner.invoke(host_module.app, ["show", mock_host.name])
+
+        assert result.exit_code == 0
+        assert "irix (Unsupported OS)" in result.output
+
+    def test_unsupported_host_no_updates_display(self, mock_host, patch_context_inventory):
+        """
+        Test that updates are not shown for unsupported hosts.
+        """
+        # Mark host as unsupported
+        mock_host.supported = False
+        mock_host.online = True
+        mock_host.os = "Darwin"
+
+        result = runner.invoke(host_module.app, ["show", mock_host.name, "--updates"])
+
+        assert result.exit_code == 0
+        assert "Update info is not available for unsupported hosts." in result.output
+
 
 class TestDiscoverCommand:
     """Tests for the 'host discover' command."""

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -350,7 +350,7 @@ class TestClearCommand:
         result = runner.invoke(inventory_module.app, ["clear"])
 
         assert result.exit_code != 0
-        assert "Confirm [y/n]" in result.output
+        assert "Clear inventory state? [y/n]" in result.output
 
     def test_confirmation(self, mocker, mock_inventory):
         """

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -230,6 +230,7 @@ class TestStatusCommand:
         assert "exotic-os" in result.output
         assert "(unsupport" in result.output  # Result will be truncated in output
         assert result.output.count("(unsupport") == 2
+        assert result.output.count("—") == 2
 
     def test_multiple_hosts_with_different_states(self, create_host, mock_inventory):
         """
@@ -295,6 +296,7 @@ class TestStatusCommand:
         assert result.output.count("Online") == 3
         assert result.output.count("Offline") == 1
         assert "2 *" in result.output  # Stale updates for server2
+        assert result.output.count("—") == 2  # Unsupported update counts
 
 
 class TestSaveCommand:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -292,3 +292,13 @@ class TestDetection:
         platform_info = platform_detect(connection)
 
         assert platform_info == expected
+
+    def test_platform_detect_error(self, connection) -> None:
+        """
+        Test for DataRefreshError during platform refresh
+        """
+
+        connection.run.side_effect = DataRefreshError("Stuff broke")
+
+        with pytest.raises(DataRefreshError, match="Stuff broke"):
+            platform_detect(connection)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -251,6 +251,7 @@ class TestDetection:
             version="12",
             flavor="debian",
             package_manager="apt",
+            is_supported=True,
         )
 
         # Call the function to test
@@ -268,3 +269,26 @@ class TestDetection:
         # Call the function and expect it to raise an OfflineHostError
         with pytest.raises(OfflineHostError):
             platform_detect(connection)
+
+    def test_platform_detect_unsupported_os(self, connection) -> None:
+        """
+        Test for platform detection with unsupported OS
+        """
+        # Mock the connection to return an unsupported OS
+        connection.run.side_effect = [
+            _run_return(False, "Darwin\n"),  # macOS - unsupported platform
+            # flavor_detect will raise UnsupportedOSError for darwin
+        ]
+
+        expected = HostInfo(
+            os="darwin",
+            version=None,
+            flavor=None,
+            package_manager=None,
+            is_supported=False,
+        )
+
+        # Call the function to test
+        platform_info = platform_detect(connection)
+
+        assert platform_info == expected

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -842,9 +842,11 @@ class TestHostObject:
             ("refresh_updates", "Update refresh is not available."),
             ("sync_repos", "Repository sync is not available"),
         ],
-        ids=["refresh_updates", "sync_repos"]
+        ids=["refresh_updates", "sync_repos"],
     )
-    def test_unsupported_host_operations(self, mocker, caplog, method_name, expected_warning):
+    def test_unsupported_host_operations(
+        self, mocker, caplog, method_name, expected_warning
+    ):
         """
         Test that operations on unsupported hosts log appropriate warnings
         """

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -595,6 +595,22 @@ class TestHostObject:
 
         assert host.is_stale is False
 
+    def test_is_stale_false_if_unsupported(self, mocker):
+        """
+        Test that unsupported hosts never return stale status
+        """
+        host = Host(name="test_host", ip="127.0.0.1")
+        host.online = True
+        host.supported = False
+
+        mocker.patch(
+            "exosphere.objects.app_config", {"options": {"stale_threshold": 60}}
+        )
+
+        host.last_refresh = datetime.now() - timedelta(seconds=30)
+
+        assert host.is_stale is False
+
     def test_sync_repos_success(
         self, mocker, mock_connection, mock_config_with_sudopolicy_pass
     ):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -603,6 +603,7 @@ class TestHostObject:
         """
         host = Host(name="test_host", ip="127.0.0.1")
         host.online = True
+        host.supported = True
 
         pkg_manager = mocker.Mock()
         pkg_manager.reposync.return_value = True
@@ -631,6 +632,7 @@ class TestHostObject:
         """
         host = Host(name="test_host", ip="127.0.0.1")
         host.online = True
+        host.supported = True
         host._pkginst = None
 
         with pytest.raises(DataRefreshError):
@@ -671,6 +673,7 @@ class TestHostObject:
 
         host = Host(name="test_host", ip="127.0.0.1", sudo_policy=SudoPolicy.SKIP)
         host.online = True
+        host.supported = True
 
         host._pkginst = mock_pkg
 
@@ -692,6 +695,7 @@ class TestHostObject:
         """
         host = Host(name="test_host", ip="127.0.0.1")
         host.online = True
+        host.supported = True
 
         pkg_manager = mocker.Mock()
         updates_list = [mocker.Mock(), mocker.Mock()]
@@ -716,6 +720,7 @@ class TestHostObject:
         """
         host = Host(name="test_host", ip="127.0.0.1")
         host.online = True
+        host.supported = True
 
         pkg_manager = mocker.Mock()
         pkg_manager.get_updates.return_value = []
@@ -748,6 +753,7 @@ class TestHostObject:
         """
         host = Host(name="test_host", ip="127.0.0.1")
         host.online = True
+        host.supported = True
         host._pkginst = None
 
         caplog.set_level("ERROR")
@@ -773,6 +779,7 @@ class TestHostObject:
 
         host = Host(name="test_host", ip="127.0.0.8", sudo_policy=SudoPolicy.SKIP)
         host.online = True
+        host.supported = True
 
         host._pkginst = mock_pkg
 
@@ -785,6 +792,7 @@ class TestHostObject:
             "Skipping updates refresh on test_host due to SudoPolicy: skip"
             in caplog.text
         )
+
     def test_host_discovery_unsupported_os(self, mocker, mock_connection):
         """
         Test that discover preserves online status for unsupported OS

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -44,6 +44,7 @@ class TestHostObject:
             version="12",
             flavor="debian",
             package_manager="apt",
+            is_supported=True,
         )
 
         mocker.patch("exosphere.setup.detect.platform_detect", return_value=hostinfo)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -453,6 +453,7 @@ class TestHostObject:
             "version": "12",
             "flavor": "debian",
             "package_manager": "apt",
+            "supported": True,
             "_connection": "THE BEFORES",
             "_pkginst": "THE BEFORES",
             "updates": [],
@@ -481,7 +482,7 @@ class TestHostObject:
         parameters that were not present when last serialized.
         """
 
-        # State without sudo_policy and connect_timeout
+        # State without sudo_policy, connect_timeout and supported
         legacy_state = {
             "name": "test_host",
             "ip": "127.0.0.1",
@@ -501,6 +502,7 @@ class TestHostObject:
         # Ensure new defaults are applied
         assert host.connect_timeout == 10
         assert host.sudo_policy == SudoPolicy.SKIP
+        assert host.supported is True
 
     def test_host_setstate_valueerror_on_missing_required(self, mocker):
         """

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -40,6 +40,7 @@ def host_unsupported():
     host = Host(name="host4", ip="127.0.0.5", description=None)
     host.online = True
     host.supported = False
+    host.os = "exotic-os"
     host.flavor = None
     host.version = None
     return host
@@ -175,7 +176,7 @@ def test_hostwidget_compose_online_unsupported(mocker, host_unsupported):
 
     calls = label_mock.call_args_list
     assert "[b]host4[/b]" in calls[0][0][0]  # name
-    assert "[dim](Unsupported)[/dim]" in calls[1][0][0]
+    assert "[dim]exotic-os (unsupported)[/dim]" in calls[1][0][0]
     assert "[green]Online[/green]" in calls[3][0][0]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "1.2.1.dev1"
+version = "1.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
This branch allows unsupported unix-like systems to be added to the inventory and gracefully function with a limited, degraded feature set.

Unsupported unix-like hosts can now be discovered, and online checks can be performed, they will show up in dashboards and tables, but users will not be able to run refresh or sync against them, for obvious reasons.

This required a significant refactor of the detection logic and internal data model to make the distinction, but the end result definitely matches user expectations a lot more.

Basically, you can still see unsupported hosts on the dashboard, even if we don't have a package manager provider for them, and Online status will no longer flap back to offline when an unsupported operation occurs, or discovery is attempted, even though a previous Ping showed it as Online.

**Documentation and Compatibility Updates:**

* Expanded documentation to clearly differentiate between fully supported platforms and those with limited or no support, including explicit lists and user guidance.

**CLI Behavior and Output Improvements:**

* Refactored the `host show` command to clearly indicate when a host is unsupported, suppress update counts for unsupported hosts, and provide improved panel formatting and validation of options.
* Updated the `inventory status` command to display "(unsupported)" for platform fields and suppress update/security counts for unsupported hosts.
* Added checks in `sudo` commands to prevent running sudo policy checks or generation for unsupported hosts, with clear error messages.

**Core Behavior Changes**
* The SSH Ping check has been changed internally to execute `true` instead of `echo "ping"`, which is much more straightforward and should guarantee compatibility with minimally POSIX compliant platforms.

**Error Messaging and Data Model:**

* Added a standardized authentication failure message in `src/exosphere/errors.py` for improved user experience.
* Extended the `HostInfo` data model to include an `is_supported` flag, enabling consistent handling of unsupported hosts throughout the application.
* Refactor exception handling in discovery process to always present the most useful error to the user and avoid confusion. Messages have been reworded to clearly indicate failure cases as well.

**Miscellaneous:**

* Bumped version to `1.3.0.dev0` and updated project description in `pyproject.toml`.
* Improved confirmation prompt wording in the `inventory clear` command.