### PR TITLE
Fix Fedora and dnf5 support in discovery, redhat provider

### DIFF
--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -68,11 +68,11 @@ Exact Commands ran on remote systems
 
    If your system uses ``yum`` you can replace ``dnf`` with it here.
 
-- ``dnf makecache --refresh --quiet -y``
-- ``dnf check-update --quiet -y``
-- ``dnf check-update --security --quiet -y``
-- ``dnf list installed --quiet -y <package_name>``
-- ``dnf repoquery -q kernel --latest-limit=1 -qf '%{NAME}.%{ARCH}\t%{VERSION}-%{RELEASE}\t%{REPOID}'``
+- ``dnf --quiet -y makecache --refresh``
+- ``dnf --quiet -y check-update``
+- ``dnf --quiet -y check-update --security``
+- ``dnf --quiet -y list installed <package_name>``
+- ``dnf --quiet -y repoquery kernel --latest-limit=1 --queryformat='%{name}.%{arch}  %{version}-%{release}  %{repoid}\n'``
 
 Command dependencies
 ^^^^^^^^^^^^^^^^^^^^
@@ -90,6 +90,9 @@ The provider is written to avoid this, but if you do encounter this, simply run
 and answer any prompts that may appear.
 
 Once that is done, you should be able to run Exosphere commands without issues.
+
+Note that we consider having to do this a bug, and would appreciate if you could
+`file a bug report`_.
 
 FreeBSD (Pkg)
 -------------
@@ -115,3 +118,5 @@ Command dependencies
 
 - `pkg`
 - `grep`
+
+.. _file a bug report: https://github.com/mrdaemon/exosphere/issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "1.3.1"
+version = "1.3.2"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/providers/redhat.py
+++ b/src/exosphere/providers/redhat.py
@@ -348,6 +348,16 @@ class Dnf(PkgManager):
             if not line or "Installed Packages" in line:
                 continue
 
+            # Stop parsing at "Available packages" section
+            # This is for DNF5 compatibility, which helpfully lists them
+            # and our clobbering logic prevents current version logic from
+            # working.
+            if "Available packages" in line:
+                self.logger.debug(
+                    "Reached 'Available packages' section, stopping parsing."
+                )
+                break
+
             parts = self._parse_line(line)
 
             if parts is None:

--- a/src/exosphere/providers/redhat.py
+++ b/src/exosphere/providers/redhat.py
@@ -43,7 +43,7 @@ class Dnf(PkgManager):
 
         with cx as c:
             update = c.run(
-                f"{self.pkgbin} makecache --refresh --quiet -y", hide=True, warn=True
+                f"{self.pkgbin} --quiet -y makecache --refresh", hide=True, warn=True
             )
 
         if update.failed:
@@ -77,7 +77,7 @@ class Dnf(PkgManager):
         # Get all other updates
         with cx as c:
             raw_query = c.run(
-                f"{self.pkgbin} check-update --quiet -y", hide=True, warn=True
+                f"{self.pkgbin} --quiet -y check-update", hide=True, warn=True
             )
 
         if raw_query.return_code == 0:
@@ -255,7 +255,7 @@ class Dnf(PkgManager):
 
         with cx as c:
             raw_query = c.run(
-                f"{self.pkgbin} check-update --security --quiet -y",
+                f"{self.pkgbin} --quiet -y check-update --security",
                 hide=True,
                 warn=True,
             )
@@ -333,7 +333,7 @@ class Dnf(PkgManager):
 
         with cx as c:
             result = c.run(
-                f"{self.pkgbin} list installed --quiet -y {' '.join(package_names)}",
+                f"{self.pkgbin} --quiet -y list installed {' '.join(package_names)}",
                 hide=True,
                 warn=True,
             )
@@ -389,7 +389,7 @@ class Yum(Dnf):
     Implements the Yum package manager interface.
     Wraps Dnf, and is mainly a compatibility layer for older systems.
     Yum and DNF thankfully have identical interfaces, but if any
-    disreptancies reveal themselves, they can be implemented here.
+    discrepancies reveal themselves, they can be implemented here.
     """
 
     def __init__(self) -> None:

--- a/src/exosphere/providers/redhat.py
+++ b/src/exosphere/providers/redhat.py
@@ -173,11 +173,11 @@ class Dnf(PkgManager):
         self.logger.debug("Querying repository for latest kernel")
 
         # Format the output to match 'check-update'
-        queryformat = "%{NAME}.%{ARCH}\t%{VERSION}-%{RELEASE}\t%{REPOID}"
+        queryformat = "%{name}.%{arch}  %{version}-%{release}  %{repoid}\n"
 
         with cx as c:
             raw_query = c.run(
-                f"{self.pkgbin} repoquery -q kernel --latest-limit=1 --qf '{queryformat}'",
+                f"{self.pkgbin} --quiet -y repoquery kernel --latest-limit=1 --queryformat='{queryformat}'",
                 hide=True,
                 warn=True,
             )

--- a/src/exosphere/providers/redhat.py
+++ b/src/exosphere/providers/redhat.py
@@ -100,7 +100,7 @@ class Dnf(PkgManager):
                 continue
 
             # Stop processing at "Obsoleting Packages" section
-            if line.startswith("Obsoleting Packages"):
+            if "obsoleting packages" in line.lower():
                 self.logger.debug(
                     "Reached 'Obsoleting Packages' section, stopping parsing."
                 )
@@ -345,14 +345,14 @@ class Dnf(PkgManager):
 
         for line in result.stdout.splitlines():
             line = line.strip()
-            if not line or "Installed Packages" in line:
+            if not line or "installed packages" in line.lower():
                 continue
 
             # Stop parsing at "Available packages" section
             # This is for DNF5 compatibility, which helpfully lists them
             # and our clobbering logic prevents current version logic from
             # working.
-            if "Available packages" in line:
+            if "available packages" in line.lower():
                 self.logger.debug(
                     "Reached 'Available packages' section, stopping parsing."
                 )

--- a/src/exosphere/setup/detect.py
+++ b/src/exosphere/setup/detect.py
@@ -20,7 +20,7 @@ from exosphere.errors import (
 )
 
 SUPPORTED_PLATFORMS = ["linux", "freebsd"]
-SUPPORTED_FLAVORS = ["ubuntu", "debian", "rhel", "freebsd"]
+SUPPORTED_FLAVORS = ["ubuntu", "debian", "rhel", "fedora", "freebsd"]
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -203,7 +203,7 @@ def version_detect(cx: Connection, flavor_name: str) -> str:
         return result_version.stdout.strip()
 
     # Redhat-likes
-    if flavor_name == "rhel":
+    if flavor_name in ["rhel", "fedora"]:
         with cx as c:
             result_version = c.run(
                 "grep ^VERSION_ID= /etc/os-release", hide=True, warn=True
@@ -216,7 +216,10 @@ def version_detect(cx: Connection, flavor_name: str) -> str:
                 stdout=result_version.stdout,
             )
 
-        return result_version.stdout.strip().split('"')[1::2][0].lower()
+        version_line = result_version.stdout.strip()
+        version_value = version_line.partition("=")[2].strip().strip("\"'")
+
+        return version_value.lower()
 
     # FreeBSD
     if flavor_name == "freebsd":
@@ -253,7 +256,7 @@ def package_manager_detect(cx: Connection, flavor_name: str) -> str:
         return "apt"
 
     # Redhat-likes
-    if flavor_name == "rhel":
+    if flavor_name in ["rhel", "fedora"]:
         with cx as c:
             result_dnf = c.run("command -v dnf", hide=True, warn=True)
             result_yum = c.run("command -v yum", hide=True, warn=True)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -58,7 +58,7 @@ class TestDetection:
         "os_name,id,like,expected",
         [
             ("linux", "ubuntu", "debian", "ubuntu"),
-            ("linux", "fedora", "rhel fedora", "rhel"),
+            ("linux", "fedora", "", "fedora"),
             ("linux", "almalinux", "rhel centos fedora", "rhel"),
             ("linux", "rockylinux", "rhel centos fedora", "rhel"),
             ("freebsd", "", "", "freebsd"),

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -543,6 +543,9 @@ class TestDnfProvider:
         systemd-libs.x86_64                   252-17.el9_5                      @baseos
         curl.x86_64                           7.76.1-18.el9_5                   @baseos
         curl-minimal.x86_64                   7.76.1-18.el9_5                   @baseos
+
+        Available packages
+        git.x86_64                            2.47.1-2.el9_6                    appstream
         """
 
         mock_return = mocker.MagicMock()
@@ -811,6 +814,11 @@ class TestDnfProvider:
         # Ensure no kernel updates are reported in this basic scenario
         kernel_updates = [u for u in updates if "kernel" in u.name]
         assert len(kernel_updates) == 0
+
+        # Ensure versions in Available package block are NOT set as
+        # currently installed version
+        git = update_by_name["git.x86_64"]
+        assert git.current_version != "2.47.1-1.el9_5"
 
     def test_get_updates_no_updates(self, mock_dnf_output_no_updates):
         """

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -669,19 +669,19 @@ class TestDnfProvider:
         mock_dnf_kernel_repoquery_return,
     ):
         def _side_effect(cmd, *args, **kwargs):
-            if "dnf check-update --security" in cmd:
+            if "check-update --security" in cmd:
                 return mock_dnf_security_output_return
-            elif "dnf check-update" in cmd:
+            elif "check-update" in cmd:
                 return mock_dnf_output_return
             elif (
-                "dnf list installed" in cmd
+                "list installed" in cmd
                 and "kernel" in cmd
                 and "kernel.x86_64" not in cmd
             ):
                 return mock_dnf_current_versions_kernel_return
-            elif "dnf list installed" in cmd:
+            elif "list installed" in cmd:
                 return mock_dnf_current_versions_return
-            elif "dnf repoquery" in cmd and "kernel" in cmd:
+            elif "repoquery" in cmd and "kernel" in cmd:
                 return mock_dnf_kernel_repoquery_return
 
         return _side_effect
@@ -770,7 +770,7 @@ class TestDnfProvider:
         result = dnf.reposync(mock_connection)
 
         mock_connection.run.assert_called_once_with(
-            "dnf makecache --refresh --quiet -y", hide=True, warn=True
+            "dnf --quiet -y makecache --refresh", hide=True, warn=True
         )
 
         assert result is expected
@@ -877,11 +877,12 @@ class TestDnfProvider:
 
         # Should contain the expected command binary in security, regular updates, and kernel queries
         assert any(
-            f"{expected_command} check-update --security" in cmd
+            f"{expected_command} --quiet -y check-update --security" in cmd
             for cmd in command_calls
         )
         assert any(
-            f"{expected_command} check-update" in cmd and "--security" not in cmd
+            f"{expected_command} --quiet -y check-update" in cmd
+            and "--security" not in cmd
             for cmd in command_calls
         )
         assert any(f"{expected_command} repoquery" in cmd for cmd in command_calls)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -619,7 +619,7 @@ class TestDnfProvider:
 
         # Mock for kernel repoquery (same version as installed = no update)
         mock_kernel = mocker.MagicMock()
-        mock_kernel.stdout = "kernel.x86_64\t5.14.0-570.18.1.el9_6\tbaseos"
+        mock_kernel.stdout = "kernel.x86_64  5.14.0-570.18.1.el9_6  baseos\n"
         mock_kernel.return_code = 0
         mock_kernel.failed = False
 
@@ -650,7 +650,7 @@ class TestDnfProvider:
         Fixture to mock the output of the dnf repoquery command for latest kernel.
         Returns the same version as the most recent installed kernel (no update needed).
         """
-        output = "kernel.x86_64\t5.14.0-570.18.1.el9_6\tbaseos"
+        output = "kernel.x86_64  5.14.0-570.18.1.el9_6  baseos\n"
 
         mock_return = mocker.MagicMock()
         mock_return.stdout = output
@@ -885,7 +885,9 @@ class TestDnfProvider:
             and "--security" not in cmd
             for cmd in command_calls
         )
-        assert any(f"{expected_command} repoquery" in cmd for cmd in command_calls)
+        assert any(
+            f"{expected_command} --quiet -y repoquery" in cmd for cmd in command_calls
+        )
 
     def test_get_updates_kernel(self, mock_kernel_test_scenario, caplog):
         """

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
Current versions of Fedora do not present an ID_LIKE field, and identify as their own distribution.
The setup module has been updated to take this into account when picking up Fedora derivatives.

Additionally, dnf5, while it tries to maintain the same interface from a UX standpoint, has a few changes that break the rhel provider, and so it has been updated to defensively parse outputs, and construct commands in the most compatible way across redhat derivatives.

* repoquery's -qf parameter has case sensitivity changes, and `-qf` does not yield the same results as full `--queryformat` for some reason
* repoquery queryformat no longer allows `\t`, no longer outputs newline
* all dnf commands REALLY insist on global options coming first, before subcommand options
* Output has various capitalization changes in blocks
* `dnf check-update` now reports new available versions in a second block. We can't make use of it given compatibility with rhel just yet, but it also needs taken in consideration so the currently installed package version does not get clobbered with the current logic.

This PR basically extends the test suite to cover for this and adapts the provider to handle both previous and current versions of dnf/yum.

All changed commands have been updated in the provider documentation as well.

Resolves #63 