### PR TITLE
Recommend uvx over uv tool in docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -56,16 +56,22 @@ The package name is `exosphere-cli`.
 
         .. code-block:: bash
 
-            uv tool install exosphere-cli
+            uvx install exosphere-cli
 
-        `uv`_ will handle downloading and installing the necessary Python
+        `uvx` will handle downloading and installing the necessary Python
         runtime and dependencies for you, and then make the `exosphere`
         command available in your PATH.
 
+        If `uvx` is not available in your version of `uv`, you can substitute
+        `uv tool` instead, which accomplishes the same thing.
 
-The ``pipx`` or ``uv tool`` methods are recommended as they create a virtual
+
+The ``pipx`` or ``uvx`` methods are recommended as they create a virtual
 environment and isolate the application, making it readily available without
 having to contend with potential conflicts with other Python packages.
+
+The main difference is that ``uvx`` will also download and manage the necessary
+Python runtime for you, if you do not have a suitable version available.
 
 ``pip install`` is **not recommended** outside of a venv, as it *will* interfere
 with other Python packages and system versions of the libraries, and many
@@ -218,7 +224,7 @@ From PyPI
 
         .. code-block:: bash
 
-            uv tool upgrade exosphere-cli
+            uvx upgrade exosphere-cli
 
 
 From Git Repository

--- a/docs/source/webui.rst
+++ b/docs/source/webui.rst
@@ -29,13 +29,7 @@ when installing Exosphere. You can do this by running:
 
         .. code-block:: shell
 
-            $ uv tool install exosphere-cli[web]
-
-    .. group-tab:: pip
-
-        .. code-block:: shell
-
-            $ pip install --user exosphere-cli[web]
+            $ uvx install exosphere-cli[web]
 
     .. group-tab:: git
 


### PR DESCRIPTION
With modern versions of `uv`, we should now recommend `uvx` over `uv tool`, although both still function and continue to do the exact same thing.

The documentation has been updated to reflect this, adding a note that if `uvx` is not available, `uv tool` can be used instead, since not everyone runs `uv self update` consistently.

Additionally: dead reference to `pip install` removed from web ui installation instructions, which should have been removed previously, but was overlooked.