### PR TITLE
Docs: document sudo requirements for FreeBSD

### DIFF
--- a/docs/source/connections.rst
+++ b/docs/source/connections.rst
@@ -99,6 +99,8 @@ pinpoint the exact issue with authentication or connectivity.
 .. _Windows OpenSSH Agent: https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement
 .. _SSH Client feature: https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
 
+.. _sudo-policies-and-privileges:
+
 Sudo Policies and Privileges
 ============================
 

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -103,6 +103,10 @@ It uses the `pkg` command to manage packages and updates.
 Repo sync *requires* sudo privileges, as it needs to run ``/usr/sbin/pkg update``
 to update the package cache from repository.
 
+This also means you will need to have the ``sudo`` package installed on the
+remote system if you want to use this functionality. Unfortunately, ``doas``
+is not supported at this time.
+
 By default, given the stock :ref:`Sudo Policy <default_sudo_policy_option>`,
 in Exosphere, Repo sync will **not** run for FreeBSD hosts, and you will need
 to configure sudoers appropriately before changing the Sudo Policy.

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -45,6 +45,8 @@ Compatibility List
 
 **BSD Systems**
   - FreeBSD (all supported versions and minor variants)
+  - Optionally requires the ``sudo`` package for repository sync operations.
+    Unfortunately ``doas`` is not supported at this time.
   - *Package Manager*: ``pkg``
 
 ☑️ Exosphere has **limited support** for the following platforms:
@@ -80,7 +82,10 @@ entirely through SSH connections and standard system utilities.
 
 **Optional Requirements**
 
-- **Elevated privileges** (sudo) for certain operations on some platforms
+- **Elevated privileges** for certain operations on some platforms (i.e. `root`)
+- ``sudo`` installed on the remote host (if needed) and :ref:`configured properly <sudo-policies-and-privileges>`
+
+See below for more details.
 
 **Network Requirements**
 


### PR DESCRIPTION
Document the fact that on FreeBSD, for reposync, or sudoers privileges to work, the user needs to explicitly install `sudo` from packages or ports on their system. `doas` is not supported, unfortunately, as `sudo` is the lowest common denominator.