### PR TITLE
Improve CLI help, add verbose switch to "inventory refresh"

### DIFF
--- a/src/exosphere/commands/config.py
+++ b/src/exosphere/commands/config.py
@@ -13,8 +13,14 @@ from rich.text import Text
 from exosphere import app_config, context, fspaths
 from exosphere.config import Configuration
 
+ROOT_HELP = """
+Configuration-related Commands
+
+Commands to inspect the currently loaded configuration.
+"""
+
 app = typer.Typer(
-    help="Configuration related commands",
+    help=ROOT_HELP,
     no_args_is_help=True,
 )
 

--- a/src/exosphere/commands/host.py
+++ b/src/exosphere/commands/host.py
@@ -28,8 +28,14 @@ SPINNER_PROGRESS_ARGS = (
     TimeElapsedColumn(),
 )
 
+ROOT_HELP = """
+Host Management Commands
+
+Commands to query, refresh and discover individual hosts.
+"""
+
 app = typer.Typer(
-    help="Host management commands",
+    help=ROOT_HELP,
     no_args_is_help=True,
 )
 
@@ -204,7 +210,8 @@ def discover(
     Gather platform data for host.
 
     This command retrieves the host by name from the inventory
-    and synchronizes its platform data.
+    and synchronizes its platform data, such as OS, version and
+    package manager.
     """
     host = get_host_or_error(name)
 
@@ -244,7 +251,7 @@ def refresh(
     Refresh the updates for a specific host.
 
     This command retrieves the host by name from the inventory
-    and refreshes its updates.
+    and refreshes its available updates.
     """
     host = get_host_or_error(name)
 

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -40,8 +40,15 @@ SPINNER_PROGRESS_ARGS = (
     TimeElapsedColumn(),
 )
 
+ROOT_HELP = """
+Inventory and Bulk Management Commands
+
+Commands to bulk query, discover and refresh hosts in the inventory.
+Most commands acccept an optional list of host names to operate on.
+"""
+
 app = typer.Typer(
-    help="Inventory and Bulk Management Commands",
+    help=ROOT_HELP,
     no_args_is_help=True,
 )
 
@@ -59,7 +66,9 @@ def discover(
     Gather platform information for hosts
 
     On a fresh inventory start, this needs done at least once before
-    operations can be performed on the hosts.
+    operations can be performed on the hosts. It can also be used to
+    refresh this information if it has changed, or if a new provider
+    has been added to Exosphere.
 
     The discover operation will connect to the specified host(s)
     and gather their current state, including Operating System, flavor,

--- a/src/exosphere/commands/sudo.py
+++ b/src/exosphere/commands/sudo.py
@@ -15,8 +15,15 @@ from exosphere.objects import Host
 from exosphere.providers.factory import PkgManagerFactory
 from exosphere.security import SudoPolicy, check_sudo_policy, has_sudo_flag
 
+ROOT_HELP = """
+Sudo Policy Management
+
+Commands to view Sudo Policies, check resultant host policies,
+list provider requirements, and generate sudoers snippets.
+"""
+
 app = typer.Typer(
-    help="Sudo Policy Management",
+    help=ROOT_HELP,
     no_args_is_help=True,
 )
 
@@ -143,9 +150,8 @@ def policy():
     """
     Show the current global Sudo Policy.
 
-    This command will display the current global Sudo Policy that is used
-    to determine if a host can execute all of its Package Manager provider
-    operations.
+    This command will display the current global Sudo Policy in effect.
+    Individual hosts may override this with their own Sudo Policy.
     """
     console.print(f"Global SudoPolicy: {_get_global_policy()}")
 
@@ -262,7 +268,7 @@ def providers(
     Show Sudo Policy requirements for available providers.
 
     Some providers require sudo privileges to execute certain operations.
-    You can use this command to list them.
+    You can use this command to what they are, if applicable.
     """
 
     # prepare a nice rich Table for providers

--- a/src/exosphere/commands/ui.py
+++ b/src/exosphere/commands/ui.py
@@ -9,8 +9,14 @@ from rich.console import Console
 
 from exosphere.ui.app import ExosphereUi
 
+ROOT_HELP = """
+Exosphere User Interface
+
+Commands to start the Text-based or Web-based User Interface.
+"""
+
 app = typer.Typer(
-    help="Exosphere UI",
+    help=ROOT_HELP,
     no_args_is_help=True,
 )
 

--- a/src/exosphere/repl.py
+++ b/src/exosphere/repl.py
@@ -358,7 +358,12 @@ class ExosphereREPL:
                 if getattr(cmd, "hidden", False):
                     continue
                 help_text = getattr(cmd, "help", None) or "No description available."
-                lines.append(f"[cyan]{name:<11}[/cyan] {help_text}")
+
+                # Show only the first line of the help text for brevity
+                # This can be a multi-line string
+                first_line = help_text.split("\n")[0]
+
+                lines.append(f"[cyan]{name:<11}[/cyan] {first_line}")
 
             if lines:
                 content = "\n".join(lines)


### PR DESCRIPTION
Improve command help by adding a multiline descrition for root commands. Formatting of titles has been unified.

Built-in REPL help has been updated to only read the first line of these when displaying the table for consistency with the Typer help system, which it closely seeks to emulate.

Boolean options for `inventory` subcommands have also been turned into flags for consistency with other commands and subcommands, i.e. instead of `--sync/--no-sync` there is now just `--sync/-s`. This makes for a less confusing experience that doesn't imply there is a default that can be changed.

Additionally, a verbose switch has been added to `inventory refresh` as `--verbose/-v` which will display host task status in real time, like `discover` does by default.