### PR TITLE
Misc docs fixes

### DIFF
--- a/docs/source/cachefile.rst
+++ b/docs/source/cachefile.rst
@@ -5,14 +5,25 @@ Exosphere saves the state of all hosts in a cache file, stored on disk.
 This allows the software to remember the state of hosts and updates between runs.
 It is `lzma`_ compressed and stored in a binary, `pickle`_ format.
 
-The cache file location is determined by the relevant option in :ref:`the configuration<cache_file_option>`.
+The cache file location can be configured with the relevant option in
+:ref:`the configuration<cache_file_option>`.
+
+The default path for the cache file varies by platform and configuration,
+but can be displayed with the command:
+
+.. code-block:: exosphere
+
+    exosphere> config paths
 
 Changing options, either globally or per host in the configuration should not be
 negatively affected by the cache file, which will update itself accordingly.
 If it does not, this is a bug and should be reported.
 
-Some effort has been made to ensure the cache file retains compatibility between
-exosphere versions, but this is unfortunately difficult to guarantee.
+.. tip::
+    Efforts are made with every major release to ensure that cache files from
+    previous versions of Exosphere remain compatible and transparently
+    upgrade on load. However, if you encounter issues, consider clearing
+    the cache as described below.
 
 Clearing the Cache
 ------------------
@@ -27,8 +38,8 @@ The cache file can also be manually cleared within exosphere in the :doc:`cli`:
 
 The confirmation prompt can be bypassed with the ``-f`` flag.
 
-Upon clearing the cache, you will have to perform a full inventory Discovery
-and subsequent Refresh again.
+Upon clearing the cache, you will have to perform a full Discovery and subsequent
+Refresh of the entire inventory to repopulate it.
 
 .. _pickle: https://docs.python.org/3/library/pickle.html
 .. _lzma: https://docs.python.org/3/library/lzma.html

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -44,6 +44,15 @@ Discovery
     This usually only needs to be done once per host, but can be repeated if any details
     change, such as a new OS version or package manager change.
 
+Refresh
+    A Refresh is the process of querying the host for its current available updates.
+    This is generally done by querying the package manager. The process is universally
+    read-only, and does not perform any system changes, aside from affecting some
+    metadata timestamps and caches on certain platforms and operating systems.
+
+    This is usually separate from a Repository Sync, but often can be combined
+    into a single operation depending on context.
+
 Repositories
     The Repositories are the generic term for the authoritative list of packages on the
     host platform. This generally consists of repositories. For instance, on Debian
@@ -51,6 +60,15 @@ Repositories
     `/etc/apt/sources.list` and friends. On RedHat-likes, it refers to the
     repositories configured in `/etc/yum.repos.d/` and so on.
 
+Repository Sync
     Synchronizing the repositories is the process of updating the local host cache
     from these remote servers, so that the next update check will have the latest
     information.
+
+    This is equivalent to running `apt-get update` on Debian-based systems,
+    or `dnf makecache` on RedHat-based systems.
+
+    This process is generally safe and read-only, but on systems where
+    sudo is required, it may update repository metadata system wide.
+    This is generally not an issue, but if it is problematic, rest assured
+    that the behavior is entirely opt-in, in these cases.


### PR DESCRIPTION
Minor misc fixes and improvements caught during development of the Reporting features that were unrelated to the change:

**Cache Section**

* Added instructions for displaying the default cache file path using the `exosphere config paths` command, clarified cache file configuration, and included a tip about cache compatibility and upgrade behavior across Exosphere versions.
* Improved wording in cache clearing section regarding how it will require the user to perform discovery and refresh from scratch.

**Glossary Section**

* Added definitions for "Refresh" and "Repository Sync," explaining their roles in update management, their read-only nature, and platform-specific details.