### PR TITLE
Maintenance/docs minor fixes

### DIFF
--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -46,7 +46,7 @@ Compatibility List
 **BSD Systems**
   - FreeBSD (all supported versions and minor variants)
   - OpenBSD (all supported versions)
-  - *Package Manager*: ``pkg`` (FreeBSD), ``pkg_add`` (OpenBSD)
+  - *Package Managers*: ``pkg`` (FreeBSD), ``pkg_add`` (OpenBSD)
 
 .. admonition:: note
 

--- a/docs/source/webui.rst
+++ b/docs/source/webui.rst
@@ -59,7 +59,7 @@ Once started, you should see output similar to:
 
 .. code-block:: shell
 
-    $ uv run exosphere ui webstart
+    $ exosphere ui webstart
     ___ ____ _  _ ___ _  _ ____ _       ____ ____ ____ _  _ ____
      |  |___  \/   |  |  | |__| |    __ [__  |___ |__/ |  | |___
      |  |___ _/\_  |  |__| |  | |___    ___] |___ |  \  \/  |___ v1.1.2


### PR DESCRIPTION
Minor fixes pre 1.5.0 release

* Updated the BSD systems compatibility list to refer to "Package Managers" instead of "Package Manager" for clarity in `docs/source/supportedos.rst`.
* Changed the example command for starting the web UI to use `exosphere ui webstart` instead of `uv run exosphere ui webstart` in `docs/source/webui.rst`.