### PR TITLE
Add Version Check feature

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -63,6 +63,8 @@ Any option left out will use the default values, which are documented below.
 
         .. literalinclude:: ../../examples/config.json
 
+.. _config_env_vars:
+
 Environment Variables
 ---------------------
 
@@ -162,6 +164,7 @@ These options are applied globally, and affect how Exosphere behaves at runtime.
 - :option:`default_timeout`
 - :option:`default_username`
 - :option:`max_threads`
+- :option:`update_checks`
 
 Below is a detailed list of all available options, their defaults,
 and examples of how to set them in the configuration file.
@@ -730,6 +733,58 @@ and examples of how to set them in the configuration file.
                 {
                     "options": {
                         "max_threads": 5
+                    }
+                }
+
+.. _update_checks_option:
+
+.. option:: update_checks
+
+    Whether or not Exosphere is allowed to check for updates on PyPI.
+
+    Exosphere currently doesn't perform any automatic update checks, only
+    when explicitly asked to via the ``version check`` command.
+
+    This option allows you to disable that functionality entirely.
+
+    This is intended for:
+
+    - Environments that have stringent policies about external connectivity
+    - Environments where Exosphere is installed by other means than PyPI
+    - Brave souls who would package Exosphere in the context of an OS distribution.
+
+    In all of these contexts, the ``version check`` command will be disabled
+    and print a clear message instead.
+
+    If in doubt, leave this at the default value.
+
+    **Default**: ``true``
+
+    **Example**:
+
+    .. tabs::
+
+        .. group-tab:: YAML
+
+            .. code-block:: yaml
+
+                options:
+                  update_checks: false
+
+        .. group-tab:: TOML
+
+            .. code-block:: toml
+
+                [options]
+                update_checks = false
+
+        .. group-tab:: JSON
+
+            .. code-block:: json
+
+                {
+                    "options": {
+                        "update_checks": false
                     }
                 }
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -198,6 +198,21 @@ that ensures it is loaded and matched last, for instance:
 
 ``/etc/sudoers.d/zz-exosphere``
 
+Is there any way to disable the update check?
+---------------------------------------------
+
+Yes, you can disable the update check by setting the ``update_checks``
+:ref:`config option <update_checks_option>` to ``false`` in the
+configuration file.
+
+This should be helpful in environments where you do not want to talk to
+PyPI at all.
+
+If you are a prospective package maintainer wishing to package Exosphere
+for your favorite platform's repositories, it is recommended that you patch
+out the default value of this option to ``False`` in ``exosphere/config.py``,
+or override via :ref:`environment variables <config_env_vars>`, if feasible.
+
 Is Windows support planned or even possible?
 ------------------------------------------------
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -202,8 +202,33 @@ Exosphere directly:
 Updating Exosphere
 ===================
 
+Exosphere often receives bug fix releases and new features.
+You can easily check if you have the latest available version of Exosphere by running:
+
+.. code-block:: exosphere
+
+    exosphere> version check
+
+or, from your operating system's shell:
+
+.. code-block:: bash
+
+    $ exosphere version check
+
+The output will tell you what version you are on, and what new version is
+available, if any.
+
 Updating Exosphere is generally as simple as installing it, depending on the installation
 method you used.
+
+Release Notes
+-------------
+
+You can (and should) consult the release notes on the `GitHub releases page`_
+to see what has changed in each release, and if there are any special instructions
+or considerations for updating.
+
+Generally, you should be able to update without any issues, however.
 
 From PyPI
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "platformdirs>=4.3.8",
     "prompt-toolkit>=3.0.51",
     "jinja2>=3.1.6",
+    "packaging>=24.0",
 ]
 
 [dependency-groups]

--- a/src/exosphere/cli.py
+++ b/src/exosphere/cli.py
@@ -11,12 +11,12 @@ and acts as the CLI entrypoint for the application.
 import logging
 from typing import Annotated
 
-from rich import print
 from rich.console import Console
 from typer import Context, Exit, Option, Typer
 
 from exosphere import __version__
-from exosphere.commands import config, host, inventory, report, sudo, ui
+from exosphere.commands import config, host, inventory, report, sudo, ui, version
+from exosphere.commands.utils import print_version
 from exosphere.repl import start_repl
 
 banner = f"""[turquoise4]
@@ -41,12 +41,13 @@ app.add_typer(ui.app, name="ui")
 app.add_typer(config.app, name="config")
 app.add_typer(report.app, name="report")
 app.add_typer(sudo.app, name="sudo")
+app.add_typer(version.app, name="version")
 
 
 @app.callback(invoke_without_command=True)
 def cli(
     ctx: Context,
-    version: Annotated[
+    show_version: Annotated[
         bool, Option("--version", "-V", help="Show version and exit")
     ] = False,
 ) -> None:
@@ -60,8 +61,8 @@ def cli(
     Run without arguments to start the interactive mode.
     """
 
-    if version:
-        print(f"Exosphere version {__version__}")
+    if show_version:
+        print_version()
         raise Exit(0)
 
     if ctx.invoked_subcommand is None:

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -14,7 +14,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress
 
-from exosphere import context
+from exosphere import __version__, context
 from exosphere.inventory import Inventory
 from exosphere.objects import Host
 
@@ -26,6 +26,17 @@ STATUS_FORMATS = {
 
 console = Console()
 err_console = Console(stderr=True)
+
+
+def print_version() -> None:
+    """
+    Print the current version of Exosphere to stdout.
+    Used by the 'version' command and '--version' option, for
+    consistent output formatting.
+    """
+    console.print(
+        f"[bold cyan]Exosphere[/bold cyan] version [bold green]{__version__}[/bold green]"
+    )
 
 
 def get_inventory() -> Inventory:

--- a/src/exosphere/commands/version.py
+++ b/src/exosphere/commands/version.py
@@ -1,0 +1,131 @@
+"""
+Version command module
+
+Commands to display and check the current version of Exosphere.
+"""
+
+import json
+import urllib.request
+from typing import Annotated
+from urllib.error import URLError
+
+import typer
+from packaging.version import parse
+
+from exosphere import __version__, app_config
+
+from .utils import console, err_console, print_version
+
+ROOT_HELP = """
+Version and Update Check Commands
+
+Show current version, check for updates.
+"""
+
+app = typer.Typer(
+    help=ROOT_HELP,
+    no_args_is_help=False,
+)
+
+PACKAGE_NAME = "exosphere-cli"
+PYPI_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
+RELEASE_URL = "https://github.com/mrdaemon/exosphere/releases/tag/"
+DOCS_URL = (
+    "https://exosphere.readthedocs.io/en/stable/installation.html#updating-exosphere"
+)
+
+
+@app.callback(invoke_without_command=True)
+def version_default(ctx: typer.Context) -> None:
+    """
+    Show the current version of Exosphere.
+
+    Displays the currently installed version. Use 'version check' to check
+    for updates on PyPI.
+    """
+    if ctx.invoked_subcommand is None:
+        print_version()
+        raise typer.Exit(0)
+
+
+@app.command()
+def check(
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Show verbose output for check"),
+    ] = False,
+) -> None:
+    """
+    Check for exosphere updates
+
+    Compares the current installed version with the latest version available
+    on PyPI and reports if an update is available.
+
+    Exits with code 3 if an update is available.
+    """
+    current_version = __version__
+    if not app_config["options"]["update_checks"]:
+        err_console.print(
+            "[yellow]Update checks are disabled via configuration.[/yellow]\n"
+            "Updates may be managed by your package manager or system administrator."
+        )
+        raise typer.Exit(0)
+
+    if verbose:
+        console.print(f"Current version: [cyan]{current_version}[/cyan]")
+        console.print(f"Checking PyPI for latest version of {PACKAGE_NAME}...")
+
+    try:
+        # Query PyPI API for package information
+        with urllib.request.urlopen(PYPI_URL, timeout=5) as response:
+            data = json.loads(response.read().decode())
+            latest_version = data["info"]["version"]
+
+        if verbose:
+            console.print(f"Latest version on PyPI: [cyan]{latest_version}[/cyan]")
+
+        # Parse out versions
+        current = parse(current_version)
+        latest = parse(latest_version)
+
+        # Compare versions
+        if current < latest:
+            console.print(
+                f"[yellow]![/yellow] A new version is available: "
+                f"[bold green]{latest_version}[/bold green] "
+                f"(current: [dim]{current_version}[/dim])\n"
+                f"\nFor release notes and instructions see: \n"
+                f"{RELEASE_URL}v{latest_version}\n"
+                f"{DOCS_URL}"
+            )
+
+            # Exit with nonzero to indicate update available
+            raise typer.Exit(3)
+        elif current > latest:
+            console.print(
+                f"[blue]*[/blue] You are using a development version: "
+                f"[blue]{current_version}[/blue] "
+                f"(latest stable: [dim]{latest_version}[/dim])"
+            )
+            raise typer.Exit(0)
+        else:
+            console.print(
+                f"You are using the latest version: "
+                f"[bold green]{current_version}[/bold green]"
+            )
+            raise typer.Exit(0)
+
+    except typer.Exit:
+        raise
+    except URLError as e:
+        err_console.print(f"[red]Error:[/red] Failed to check for updates: {e}")
+        err_console.print("[yellow]Please check internet connectivity.[/yellow]")
+        raise typer.Exit(1)
+    except KeyError as e:
+        err_console.print(
+            f"[red]Error:[/red] Unexpected response from PyPI API (missing key: {e})"
+        )
+        raise typer.Exit(1)
+    except Exception as e:
+        err_console.print(f"[red]Error:[/red] Failed to check for updates: {e}")
+        raise typer.Exit(1)

--- a/src/exosphere/config.py
+++ b/src/exosphere/config.py
@@ -55,6 +55,7 @@ class Configuration(dict):
             "default_username": None,  # Default global username to use for SSH
             "default_sudo_policy": "skip",  # Global sudo policy for package manager ops
             "max_threads": 15,  # Maximum number of threads to use for parallel ops
+            "update_checks": True,  # Set to false if you want to disable PyPI checks
         },
         "hosts": [],
     }

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -1,0 +1,222 @@
+"""
+Tests for the version command module.
+"""
+
+import json
+from urllib.error import URLError
+
+import pytest
+from typer.testing import CliRunner
+
+from exosphere.commands import version
+from exosphere.config import Configuration
+
+runner = CliRunner(env={"NO_COLOR": "1"})
+
+
+@pytest.fixture
+def mock_version(mocker):
+    """Mock the __version__ variable."""
+    return mocker.patch("exosphere.commands.version.__version__", "1.5.0")
+
+
+@pytest.fixture
+def mock_urlopen(mocker):
+    """Mock urllib.request.urlopen for PyPI API calls."""
+    return mocker.patch("exosphere.commands.version.urllib.request.urlopen")
+
+
+@pytest.fixture
+def app_config(mocker):
+    """
+    Fixture to patch the app_config with a fresh configuration object.
+    """
+    config_object = Configuration()
+    # Enable PyPI checks by default in tests
+    # This should be the stock defaults but we explicitly set it here
+    # for consistency of results, should this ever change.
+    config_object.update_from_mapping({"options": {"update_checks": True}})
+    mocker.patch("exosphere.commands.version.app_config", config_object)
+    return config_object
+
+
+@pytest.fixture
+def app_config_pypi_disabled(mocker):
+    """
+    Fixture to patch the app_config with PyPI checks disabled.
+    """
+    config_object = Configuration()
+    config_object.update_from_mapping({"options": {"update_checks": False}})
+    mocker.patch("exosphere.commands.version.app_config", config_object)
+    return config_object
+
+
+@pytest.fixture
+def create_pypi_response(mocker):
+    """
+    Factory fixture that creates mock PyPI API responses
+
+    Returned function takes a version string and returns a configured mock.
+    """
+
+    def _create_response(version_string: str):
+        response_data = {"info": {"version": version_string}}
+        mock_response = mocker.Mock()
+        mock_response.__enter__ = mocker.Mock(return_value=mock_response)
+        mock_response.__exit__ = mocker.Mock(return_value=False)
+        mock_response.read.return_value = json.dumps(response_data).encode("utf-8")
+        return mock_response
+
+    return _create_response
+
+
+class TestVersionDefault:
+    """Tests for the default version command (no subcommand)."""
+
+    def test_version_default_displays_version(self):
+        """Test that the default version command displays the version."""
+        result = runner.invoke(version.app, [])
+
+        assert result.exit_code == 0
+        assert "Exosphere version" in result.output
+
+    def test_version_help(self):
+        """
+        Test that version --help shows the help message.
+
+        Additionally, default command should not fire off
+        """
+        result = runner.invoke(version.app, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Version and Update Check Commands" in result.output
+        assert "check" in result.output
+
+
+class TestVersionCheck:
+    """Tests for the 'version check' command."""
+
+    def test_check_update_available(
+        self, mock_urlopen, app_config, mocker, create_pypi_response
+    ):
+        """Test check when an update is available."""
+        # Mock current version as older version
+        mocker.patch("exosphere.commands.version.__version__", "1.4.0")
+
+        # Mock PyPI response with newer version
+        mock_urlopen.return_value = create_pypi_response("1.5.0")
+
+        result = runner.invoke(version.app, ["check"])
+
+        assert "new version is available" in result.output
+        assert "1.5.0" in result.output
+        assert result.exit_code == 3
+
+    def test_check_latest_version(
+        self, mock_urlopen, mock_version, app_config, create_pypi_response
+    ):
+        """Test check when using the latest version."""
+        # Mock PyPI response with same version
+        mock_urlopen.return_value = create_pypi_response("1.5.0")
+
+        result = runner.invoke(version.app, ["check"])
+
+        assert result.exit_code == 0
+        assert "latest version" in result.output
+
+    def test_check_development_version(
+        self, mock_urlopen, app_config, mocker, create_pypi_response
+    ):
+        """Test check when using a development version."""
+        # Mock current version as development version (newer than stable)
+        mocker.patch("exosphere.commands.version.__version__", "1.6.0.dev0")
+
+        # Mock PyPI response with older stable version
+        mock_urlopen.return_value = create_pypi_response("1.5.0")
+
+        result = runner.invoke(version.app, ["check"])
+
+        assert result.exit_code == 0
+        assert "development version" in result.output
+
+    @pytest.mark.parametrize("verbose_flag", ["--verbose", "-v"], ids=["long", "short"])
+    def test_check_verbose(
+        self, mock_urlopen, mock_version, app_config, verbose_flag, create_pypi_response
+    ):
+        """Test check with verbose flag."""
+        # Mock PyPI response
+        mock_urlopen.return_value = create_pypi_response("1.5.0")
+
+        result = runner.invoke(version.app, ["check", verbose_flag])
+
+        assert result.exit_code == 0
+        # Verbose should print current version and checking message
+        assert "Current version" in result.output or "Checking PyPI" in result.output
+
+    def test_check_network_error(self, mock_urlopen, mock_version, app_config):
+        """Test check with network error."""
+        # Mock urlopen to raise URLError
+        mock_urlopen.side_effect = URLError("Network unreachable")
+
+        result = runner.invoke(version.app, ["check"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.output or "Failed" in result.output
+
+    def test_check_malformed_pypi_response(
+        self, mock_urlopen, mock_version, app_config, mocker
+    ):
+        """Test check with malformed PyPI response (missing version key)."""
+        # Mock PyPI response with missing 'version' key
+        response_data = {"info": {}}  # Missing 'version' key
+        mock_response = mocker.Mock()
+        mock_response.__enter__ = mocker.Mock(return_value=mock_response)
+        mock_response.__exit__ = mocker.Mock(return_value=False)
+        mock_response.read.return_value = json.dumps(response_data).encode("utf-8")
+        mock_urlopen.return_value = mock_response
+
+        result = runner.invoke(version.app, ["check"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.output or "Unexpected" in result.output
+
+    def test_check_invalid_json_response(
+        self, mock_urlopen, mock_version, app_config, mocker
+    ):
+        """Test check with invalid JSON response from PyPI."""
+        # Mock PyPI response with invalid JSON
+        mock_response = mocker.Mock()
+        mock_response.__enter__ = mocker.Mock(return_value=mock_response)
+        mock_response.__exit__ = mocker.Mock(return_value=False)
+        mock_response.read.return_value = b"Not valid JSON"
+        mock_urlopen.return_value = mock_response
+
+        result = runner.invoke(version.app, ["check"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.output or "Failed" in result.output
+
+    def test_check_pypi_disabled(self, mock_urlopen, app_config_pypi_disabled):
+        """Test check when PyPI checks are disabled via configuration."""
+        result = runner.invoke(version.app, ["check"])
+
+        mock_urlopen.assert_not_called()
+        assert "disabled" in result.output.lower()
+        assert result.exit_code == 0
+
+    def test_check_timeout(
+        self, mock_urlopen, mock_version, app_config, create_pypi_response
+    ):
+        """Test that urlopen is called with correct timeout."""
+        # Mock PyPI response
+        mock_urlopen.return_value = create_pypi_response("1.5.0")
+
+        runner.invoke(version.app, ["check"])
+
+        # Verify urlopen was called with timeout parameter
+        mock_urlopen.assert_called_once()
+        call_args = mock_urlopen.call_args
+        # Check that timeout was passed (either as kwarg or in args)
+        assert call_args.kwargs.get("timeout") == 5 or (
+            len(call_args.args) > 1 and call_args.args[1] == 5
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -441,6 +441,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fabric" },
     { name = "jinja2" },
+    { name = "packaging" },
     { name = "platformdirs" },
     { name = "prompt-toolkit" },
     { name = "pyyaml" },
@@ -478,6 +479,7 @@ dev = [
 requires-dist = [
     { name = "fabric", specifier = ">=3.2.2" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pyyaml", specifier = ">=6.0.2" },


### PR DESCRIPTION
This pull request introduces a new `version` command to Exosphere, allowing users to display the current version and check for updates on PyPI.

The root level `--version` argument remains for backwards compatibility, but calls the same code as `exosphere version`.

It also adds a configuration option to disable update checks, provides comprehensive documentation for these features, and includes a full test suite for the new command.

The version check command can handle development versions just fine and will report them as such.