### PR TITLE
Add ability to filter output of inventory status

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -137,6 +137,17 @@ You can also select one or more specific hosts by providing their names as argum
 This will show the status for only those hosts, allowing you to focus on
 specific systems.
 
+You can also filter the output to only show hosts with available updates by
+using the ``--updates-only`` or ``--security-only`` flags:
+
+.. code-block:: exosphere
+
+   exosphere> inventory status --updates-only
+   exosphere> inventory status --security-only
+
+If this results in no hosts matching the criteria, Exosphere will print
+a message and exit with **code 2**.
+
 Viewing Host Details and Updates
 --------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "1.5.0"
+version = "1.5.1.dev0"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "1.5.0"
+version = "1.5.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
Can now filter based on presence of updates or security updates. Will exit with code 2 on no match. 

Additionally: Correctly raise nonzero exit on empty inventory instead of returning early across all inventory commands.