### PR TITLE
Prepare 1.5.1 Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "1.5.1.dev0"
+version = "1.5.1"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "1.5.1.dev0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
Minor point release introducing a minor QoL improvement that is fully backwards compatible, as well as Python 3.14 uv housekeeping.

* Ability to filter `inventory status` output with `--updates-only` and `--security-only`.
* Update uv lockfile dependencies for Python 3.14 support in various libraries