### PR TITLE
Github: Add test matrix for ci workflow

### DIFF
--- a/.github/workflows/exosphere-test.yml
+++ b/.github/workflows/exosphere-test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Since Python 3.14 has released, it is time to grudgingly add a test matrix for all supported versions.
Forward compatibility is easier than backwards compatibility, so this should be fine for now.

The CI job that runs the test suite now runs on both 3.13 and 3.14 and produces reports for both.

Additionally, the setup-python action has been updated to v6