### PR TITLE
Uniformize return codes across application

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -146,7 +146,7 @@ using the ``--updates-only`` or ``--security-only`` flags:
    exosphere> inventory status --security-only
 
 If this results in no hosts matching the criteria, Exosphere will print
-a message and exit with **code 2**.
+a message and exit with **code 3**.
 
 Viewing Host Details and Updates
 --------------------------------
@@ -265,6 +265,28 @@ allowing you to run more targeted or specialized commands.
    logs, and includes a nice built-in scrollable viewer.
 
 For more details on the TUI, continue on to the :doc:`ui` page.
+
+Return Codes
+------------
+
+Exosphere uses specific return codes to indicate the outcome of commands.
+Key return codes are typically:
+
+- **0**: Success - The command completed successfully without any issues.
+- **1**: Execution Error - An error occurred during the execution of the command.
+- **2**: Argument Error - There was an issue with the provided arguments or options.
+- **3**: Special - A condition was met, not necessarily an error
+
+The special return code (3) is used very deliberately and is intended to
+assist with scripting and automation, where you need to differentiate between
+errors and specific conditions.
+
+For instance, ``exosphere version check`` will return 3 if updates are available,
+and the various ``--updates-only`` filters on ``inventory status`` will also
+return 3 if no hosts matched what you requested.
+
+Commands returning 3 will typically inform you of the meaning in their
+help text.
 
 Beyond the Basics
 -----------------

--- a/src/exosphere/commands/config.py
+++ b/src/exosphere/commands/config.py
@@ -68,7 +68,7 @@ def show(
             err_console.print(
                 f"[red]Option '{option}' not found in configuration.[/red]"
             )
-            raise typer.Exit(1)
+            raise typer.Exit(1)  # Execution error
 
         return
 

--- a/src/exosphere/commands/host.py
+++ b/src/exosphere/commands/host.py
@@ -169,14 +169,14 @@ def show(
     """
     host = get_host_or_error(name)
     if host is None:
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=2)  # Argument error
 
     # Validate options
     if not include_updates and security_only:
         err_console.print(
             "[red]Error: --security-only option is only valid with --updates.[/red]"
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=2)  # Argument error
 
     # Display main host information panel
     panel_content = _make_host_panel_content(host)
@@ -216,7 +216,7 @@ def discover(
     host = get_host_or_error(name)
 
     if host is None:
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=2)  # Argument error
 
     with Progress(*SPINNER_PROGRESS_ARGS) as progress:
         progress.add_task(f"Discovering platform for '{host.name}'", total=None)
@@ -231,7 +231,7 @@ def discover(
                     title_align="left",
                 )
             )
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1)  # Execution error
 
     if app_config["options"]["cache_autosave"]:
         save_inventory()
@@ -256,7 +256,7 @@ def refresh(
     host = get_host_or_error(name)
 
     if host is None:
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=2)  # Argument error
 
     with Progress(transient=True, *SPINNER_PROGRESS_ARGS) as progress:
         if discover:
@@ -275,7 +275,7 @@ def refresh(
                     )
                 )
                 progress.stop_task(task)
-                raise typer.Exit(code=1)
+                raise typer.Exit(code=1)  # Execution error
 
             progress.stop_task(task)
 
@@ -295,7 +295,7 @@ def refresh(
                     )
                 )
                 progress.stop_task(task)
-                raise typer.Exit(code=1)
+                raise typer.Exit(code=1)  # Execution error
 
             progress.stop_task(task)
 
@@ -312,7 +312,7 @@ def refresh(
                 )
             )
             progress.stop_task(task)
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1)  # Execution error
 
     if app_config["options"]["cache_autosave"]:
         save_inventory()
@@ -333,7 +333,7 @@ def ping(
     host = get_host_or_error(name)
 
     if host is None:
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=2)  # Argument error
 
     if host.ping():
         console.print(

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -83,7 +83,7 @@ def discover(
     hosts = get_hosts_or_error(names)
 
     if hosts is None:
-        raise typer.Exit(1)
+        raise typer.Exit(2)  # Argument error
 
     errors = run_task_with_progress(
         inventory=inventory,
@@ -108,7 +108,7 @@ def discover(
             errors_table.add_row(host, f"[bold red]{error}[/bold red]")
 
         console.print(errors_table)
-        exit_code = 1
+        exit_code = 1  # Execution error
 
     if app_config["options"]["cache_autosave"]:
         save()
@@ -167,7 +167,7 @@ def refresh(
     hosts = get_hosts_or_error(names)
 
     if hosts is None:
-        raise typer.Exit(1)
+        raise typer.Exit(2)  # Argument error
 
     # Start with discovery, if requested.
     # Displays a simple spinner with no ETA, and no progress bar.
@@ -233,7 +233,7 @@ def refresh(
 
         console.print(errors_table)
 
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1)  # Execution error
 
 
 @app.command()
@@ -267,7 +267,7 @@ def ping(
 
     if hosts is None:
         logger.error("No host(s) found, aborting")
-        raise typer.Exit(1)
+        raise typer.Exit(2)  # Argument error
 
     with Progress(
         transient=True,
@@ -296,7 +296,7 @@ def ping(
         save()
 
     if error_count > 0:
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1)  # Execution error
 
 
 @app.command()
@@ -335,16 +335,14 @@ def status(
     updates or security updates. Filtering for security updates
     implies filtering for updates as well.
 
-    No matches for filtering will exit with code 2.
-
-    This is the main CLI UI for the inventory.
+    No matches when filtering will exit with code 3.
     """
     logger = logging.getLogger(__name__)
     logger.info("Showing status of all hosts")
 
     hosts = get_hosts_or_error(names)
     if hosts is None:
-        raise typer.Exit(1)
+        raise typer.Exit(2)  # Argument error
 
     # Apply filters and set table title based on active flags
     # Note: security_only implies updates_only as they're a subset,
@@ -361,7 +359,7 @@ def status(
 
     if not hosts:
         console.print(Panel.fit("No hosts matching requested criteria."))
-        raise typer.Exit(2)
+        raise typer.Exit(3)  # No matches for filtering
 
     # Iterates through all hosts in the inventory and render a nice
     # Rich table with their properties and status
@@ -465,7 +463,7 @@ def save() -> None:
                     style="bold red",
                 ),
             )
-            raise typer.Exit(1)
+            raise typer.Exit(1)  # Execution error
 
     logger.debug("Inventory save operation completed")
 
@@ -498,7 +496,7 @@ def clear(
     inventory: Inventory = get_inventory()
     if not confirm:
         console.print("Inventory state has [bold]not[/bold] been cleared.")
-        raise typer.Exit(1)
+        raise typer.Exit(2)  # Argument error
 
     try:
         inventory.clear_state()
@@ -509,7 +507,7 @@ def clear(
                 style="bold red",
             )
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1)  # Execution error
     else:
         console.print(
             Panel.fit(

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -114,7 +114,7 @@ def generate(
 
     selected_hosts = get_hosts_or_error(hosts, supported_only=True)
     if selected_hosts is None:
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=2)  # Argument error
 
     # Record count of hosts involved in the report before
     # any kind of filtering. This is used by the report to
@@ -162,7 +162,7 @@ def generate(
         # This should never happen due to early validation
         err_console.print(f"[red]Internal Error: Unsupported format: {format}[/red]")
         err_console.print("This is a bug and should be reported.")
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1)  # Execution error, technically
 
     content = render_method(
         selected_hosts,
@@ -178,7 +178,7 @@ def generate(
             output.write_text(content, encoding="utf-8")
         except Exception as e:
             err_console.print(f"[red]Failed to write to {output}: {e}[/red]")
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1)  # Execution error
 
         if not tee and not quiet:
             err_console.print(

--- a/src/exosphere/commands/ui.py
+++ b/src/exosphere/commands/ui.py
@@ -45,7 +45,7 @@ def webstart() -> None:
             "The Exosphere Web UI component is not installed. "
             r"Please install 'exosphere-cli\[web]' to use this feature."
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=2)  # Argument error
     else:
         logger.info("Starting Exosphere Web UI Server")
         server = Server(command="exosphere ui start")

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -126,7 +126,7 @@ def get_inventory() -> Inventory:
             "Inventory is not initialized, are you running this module directly?",
             err=True,
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1)  # Execution error
 
     return context.inventory
 

--- a/src/exosphere/commands/version.py
+++ b/src/exosphere/commands/version.py
@@ -132,12 +132,12 @@ def check(
     except URLError as e:
         err_console.print(f"[red]Error:[/red] Failed to check for updates: {e}")
         err_console.print("[yellow]Please check internet connectivity.[/yellow]")
-        raise typer.Exit(1)
+        raise typer.Exit(1)  # Execution error
     except KeyError as e:
         err_console.print(
             f"[red]Error:[/red] Unexpected response from PyPI API (missing key: {e})"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(1)  # Execution error
     except Exception as e:
         err_console.print(f"[red]Error:[/red] Failed to check for updates: {e}")
-        raise typer.Exit(1)
+        raise typer.Exit(1)  # Execution error

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -143,7 +143,7 @@ class TestShowCommand:
         """
         result = runner.invoke(host_module.app, ["show", "not_test_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert not hasattr(mock_host, "discovered")
 
     def test_with_last_refresh_date(self, mock_host, patch_context_inventory):
@@ -174,7 +174,7 @@ class TestShowCommand:
             host_module.app, ["show", mock_host.name, "--no-updates", "--security-only"]
         )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2  # Argument error
         assert (
             "Error: --security-only option is only valid with --updates"
             in result.output
@@ -245,7 +245,7 @@ class TestDiscoverCommand:
         """
         result = runner.invoke(host_module.app, ["discover", "not_test_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2  # Expect argument error
         assert not hasattr(mock_host, "discovered")
 
     def test_with_exception(self, mock_host, patch_context_inventory):
@@ -349,7 +349,7 @@ class TestRefreshCommand:
         """
         result = runner.invoke(host_module.app, ["refresh", "not_test_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
 
 class TestPingCommand:
@@ -360,7 +360,7 @@ class TestPingCommand:
         [
             (True, True, 0),
             (True, False, 0),
-            (False, None, 1),
+            (False, None, 2),
         ],
         ids=["exists_online", "exists_offline", "not_exists"],
     )

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -105,7 +105,7 @@ class TestStatusCommand:
         result = runner.invoke(inventory_module.app, ["status"])
 
         assert "No hosts found in inventory." in result.output
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
     def test_with_specific_hosts(self, create_host, mock_inventory):
         """
@@ -370,7 +370,7 @@ class TestStatusCommand:
     def test_no_hosts_matching_criteria(self, create_host, mock_inventory):
         """
         Test status command when filters result in no matching hosts.
-        Should show a message and exit with code 2.
+        Should show a message and exit with code 3.
         """
         host_no_updates = create_host(name="host1", updates=[], security_updates=[])
 
@@ -378,7 +378,7 @@ class TestStatusCommand:
 
         result = runner.invoke(inventory_module.app, ["status", "--updates-only"])
 
-        assert result.exit_code == 2
+        assert result.exit_code == 3
         assert "No hosts matching requested criteria" in result.output
         assert "host1" not in result.output
 
@@ -585,7 +585,7 @@ class TestDiscoverCommand:
 
         result = runner.invoke(inventory_module.app, ["discover"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "No hosts found in inventory." in result.output
 
     @pytest.mark.parametrize(
@@ -729,7 +729,7 @@ class TestPingCommand:
 
         result = runner.invoke(inventory_module.app, ["ping"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         mock_get_hosts_or_error.assert_called_once_with(None)
         mock_inventory.run_task.assert_not_called()
 
@@ -972,7 +972,7 @@ class TestRefreshCommand:
 
         result = runner.invoke(inventory_module.app, ["refresh"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         mock_get_hosts_or_error.assert_called_once_with(None)
         mock_run_task_with_progress.assert_not_called()
 

--- a/tests/commands/test_report.py
+++ b/tests/commands/test_report.py
@@ -227,8 +227,8 @@ class TestGenerateCommand:
     @pytest.mark.parametrize(
         "hosts,expected_exit_code",
         [
-            ("unsupported_hosts", 1),
-            (None, 1),
+            ("unsupported_hosts", 2),
+            (None, 2),
         ],
         ids=["no_supported_hosts", "host_lookup_failure"],
     )

--- a/tests/commands/test_sudo.py
+++ b/tests/commands/test_sudo.py
@@ -154,7 +154,7 @@ class TestCheckCommand:
         Test that help is displayed when no host is specified.
         """
         result = runner.invoke(sudo.app, ["check", "testhost"])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Host 'testhost' not found in inventory!" in result.output
 
     def test_basic_check(self, mock_inventory, dummy_host):
@@ -231,7 +231,7 @@ class TestCheckCommand:
 
         result = runner.invoke(sudo.app, ["check", "dummy_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Host 'dummy_host' is not running a supported OS." in result.output
 
 
@@ -267,7 +267,7 @@ class TestProvidersCommand:
         """
         result = runner.invoke(sudo.app, ["providers", "unknown_provider"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "No such provider: unknown_provider" in result.output
 
     @pytest.mark.parametrize(
@@ -315,7 +315,7 @@ class TestGenerateCommand:
         """
         result = runner.invoke(sudo.app, ["generate"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "You must specify either --host or --provider" in result.output
 
     def test_host_and_provider_mutually_exclusive(
@@ -332,7 +332,7 @@ class TestGenerateCommand:
             sudo.app, ["generate", "--host", "dummy_host", "--provider", "apt"]
         )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "--host and --provider are mutually exclusive" in result.output
 
     def test_with_host(self, mock_inventory, dummy_host, mock_pkgmanager_factory):
@@ -357,7 +357,7 @@ class TestGenerateCommand:
 
         result = runner.invoke(sudo.app, ["generate", "--host", "invalid_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Host 'invalid_host' not found in inventory!" in result.output
 
     def test_with_host_undiscovered(
@@ -372,7 +372,7 @@ class TestGenerateCommand:
 
         result = runner.invoke(sudo.app, ["generate", "--host", "dummy_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Host 'dummy_host' does not have a package manager" in result.output
 
     def test_with_host_unsupported(
@@ -387,7 +387,7 @@ class TestGenerateCommand:
 
         result = runner.invoke(sudo.app, ["generate", "--host", "dummy_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Host 'dummy_host' is not running a supported OS." in result.output
 
     def test_with_host_no_username_fallback(
@@ -464,7 +464,7 @@ class TestGenerateCommand:
 
         result = runner.invoke(sudo.app, ["generate", "--host", "dummy_host"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "No username could be selected" in result.output
 
     def test_with_username_provided_but_invalid(
@@ -481,7 +481,7 @@ class TestGenerateCommand:
             sudo.app, ["generate", "--host", "dummy_host", "--user", "invalid\\;;user!"]
         )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "Invalid username 'invalid\\;;user!'" in result.output
 
     @pytest.mark.parametrize(
@@ -517,7 +517,7 @@ class TestGenerateCommand:
         """
         result = runner.invoke(sudo.app, ["generate", "--provider", "unknown_provider"])
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "No such provider: unknown_provider" in result.output
 
     def test_with_provider_and_username(self, app_config, mock_pkgmanager_factory):
@@ -542,7 +542,7 @@ class TestGenerateCommand:
         """
         result = runner.invoke(sudo.app, ["generate", "--provider", "dnf"])
 
-        assert result.exit_code == 0
+        assert result.exit_code == 2
         assert "Provider 'dnf' does not require any sudo commands" in result.output
 
     def test_with_provider_no_sudo_commands_defined(self, mock_pkgmanager_factory):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,7 @@ def test_ui_webstart_without_extras(mocker, caplog, monkeypatch) -> None:
 
     result = runner.invoke(sub_ui_cli, ["webstart"])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     mock_console.assert_called_with(stderr=True)
     assert (
         "not installed" in result.output.lower()


### PR DESCRIPTION
- 0 for success
- 1 for execution error (something we did)
- 2 for argument errors (something we were given)
- 3 For special (update available, no match on filter etc)

Documentation has been updated to reflect this, tests have been amended to expect it.