### PR TITLE
Bump version to 2.0.0 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "1.5.2"
+version = "2.0.0"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "1.5.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
Version changed to 2.0.0 purely because strictly speaking, unification of return codes changes the expected API contract, so we increment a major to communicate this.