### PR TITLE
Fix version check should return 1 when disabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "2.0.0"
+version = "2.0.1"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/commands/version.py
+++ b/src/exosphere/commands/version.py
@@ -81,7 +81,7 @@ def check(
             "[yellow]Update checks are disabled via configuration.[/yellow]\n"
             "Updates may be managed by your package manager or system administrator."
         )
-        raise typer.Exit(0)
+        raise typer.Exit(1)
 
     if verbose:
         console.print(f"Current version: [cyan]{current_version}[/cyan]")

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -220,7 +220,7 @@ class TestVersionCheck:
 
         mock_urlopen.assert_not_called()
         assert "disabled" in result.output.lower()
-        assert result.exit_code == 0
+        assert result.exit_code == 1
 
     def test_check_timeout(
         self, mock_urlopen, mock_version, app_config, create_pypi_response

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
Previously returned 0, failure should be explicit.

Fixes #111 