### PR TITLE
REPL: Prevent double completion in help full match

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "2.1.0.dev3"
+version = "2.1.0.dev4"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/repl.py
+++ b/src/exosphere/repl.py
@@ -132,13 +132,13 @@ class ExosphereCompleter(Completer):
         sp = -len(words[0]) if words and prefix else 0
         return self._make_completions(matches, sp)
 
-    def _complete_help_command(self, words: list[str]) -> list[Completion]:
+    def _complete_help_command(self, words: list[str], text: str) -> list[Completion]:
         """Complete the 'help' builtin command with available commands."""
         if not self.root_command:
             return []
 
         main_commands = getattr(self.root_command, "commands", {})
-        current = words[1] if len(words) > 1 else ""
+        current = "" if text.endswith(" ") else (words[1] if len(words) > 1 else "")
         matching = [name for name in main_commands if name.startswith(current)]
 
         return self._make_completions(matching, -len(current))
@@ -324,7 +324,7 @@ class ExosphereCompleter(Completer):
         command = words[0]
         if command in ("help", "exit", "quit"):
             if command == "help" and len(words) <= 2:
-                yield from self._complete_help_command(words)
+                yield from self._complete_help_command(words, text)
             return
 
         # Handle exosphere commands from the root command

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "2.1.0.dev3"
+version = "2.1.0.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
This pull request improves the tab-completion behavior for the `help` command in the Exosphere CLI, ensuring that completions are not duplicated when the user has already typed a complete command followed by a space. It also adds a regression test to prevent this issue in the future.