### PR TITLE
Fix documentation for default_sudo_policy

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -258,14 +258,14 @@ and examples of how to set them in the configuration file.
             .. code-block:: yaml
 
                 options:
-                  sudo_policy: nopasswd
+                  default_sudo_policy: nopasswd
 
         .. group-tab:: TOML
 
             .. code-block:: toml
 
                 [options]
-                sudo_policy = "nopasswd"
+                default_sudo_policy = "nopasswd"
 
         .. group-tab:: JSON
 
@@ -273,7 +273,7 @@ and examples of how to set them in the configuration file.
 
                 {
                     "options": {
-                        "sudo_policy": "nopasswd"
+                        "default_sudo_policy": "nopasswd"
                     }
                 }
 


### PR DESCRIPTION
The example was using the wrong key name ('sudo_policy' vs 'default_sudo_policy').