### PR TITLE
Dashboard: add ~3chars tolerance in sizing columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "2.1.0.dev6"
+version = "2.1.0.dev7"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/ui/dashboard.py
+++ b/src/exosphere/ui/dashboard.py
@@ -150,7 +150,15 @@ class DashboardScreen(Screen):
 
         terminal_width = self.size.width
         min_tile_width = MIN_WIDGET_WIDTH
-        max_columns = max(1, terminal_width // min_tile_width)
+
+        columns_exact = terminal_width / min_tile_width
+        max_columns = int(columns_exact)
+
+        # If we're within 3 characters of fitting another column, allow it
+        if columns_exact - max_columns >= 0.88:  # ~22 of 25 chars
+            max_columns += 1
+
+        max_columns = max(1, max_columns)
 
         # Cap grid columns between minimum and maximum
         columns = min(max(MIN_GRID_COLUMNS, max_columns), MAX_GRID_COLUMNS)

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "2.1.0.dev6"
+version = "2.1.0.dev7"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
This makes the dashboard slightly less likely to present 3 extra wide columns for the tiles, when four would definitely fit anyways.