### PR TITLE
Hotfix: Textual version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "2.1.0"
+version = "2.1.1"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
`compact` as a kwarg to the constructor on Footer widgets has come and gone through versions of Textual, to reappear in 6.2.0 -- we now set our minimum version to that.

Resolves issue where switching to the inventory screen gives you:

```
TypeError: InventoryScreen() compose() method returned an invalid result; Footer.__init__() got an unexpected keyword argument 'compact'
```