### PR TITLE
Add basic integration tests for TUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "poethepoet>=0.33.1",
     "pyright>=1.1.400",
     "pytest>=8.3.5",
+    "pytest-asyncio>=1.2.0",
     "pytest-cov>=6.1.1",
     "pytest-json-ctrf>=0.3.5",
     "pytest-mock>=3.14.0",

--- a/tests/ui/test_integration.py
+++ b/tests/ui/test_integration.py
@@ -1,0 +1,110 @@
+"""
+Integration tests for the Text User Interface (TUI) screens.
+
+This test suite should detect General Issues with any of the UI screen.
+They mostly serve as smoke tests to catch errors during screen composition.
+
+They _actually_ use the Textual testing framework, unlike the rest of the
+stupid tests in this project.
+
+Tests are marked with @pytest.mark.asyncio to enable async test execution,
+which is done explicitly because I want to contain asyncio to its own
+awful little corner of hell instead of spreading it everywhere.
+"""
+
+import pytest
+
+from exosphere.ui.app import ExosphereUi
+from exosphere.ui.dashboard import DashboardScreen
+from exosphere.ui.inventory import InventoryScreen
+from exosphere.ui.logs import LogsScreen
+
+
+@pytest.mark.asyncio
+async def test_app_starts_and_shows_dashboard():
+    """
+    Test that the app starts successfully and displays the dashboard.
+
+    This is a smoke test that verifies the app can be instantiated
+    and the initial screen (dashboard) can be composed without errors.
+    """
+    app = ExosphereUi()
+    async with app.run_test() as pilot:
+        # App should start on dashboard
+        assert isinstance(app.screen, DashboardScreen)
+
+        # Give it a moment to settle
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_inventory_screen():
+    """
+    Test navigation to the inventory screen (key: i).
+
+    This test ensures the InventoryScreen can be composed and displayed,
+    which would catch issues like Footer(compact=True) with incompatible
+    Textual versions.
+
+    This very regression is what prompted this entire test suite.
+    """
+    app = ExosphereUi()
+    async with app.run_test() as pilot:
+        # Navigate to inventory screen
+        await pilot.press("i")
+        await pilot.pause()
+
+        # Should be on inventory screen
+        assert isinstance(app.screen, InventoryScreen)
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_logs_screen():
+    """
+    Test navigation to the logs screen (key: l).
+
+    Verifies the LogsScreen can be composed and displayed.
+    """
+    app = ExosphereUi()
+    async with app.run_test() as pilot:
+        # Navigate to logs screen
+        await pilot.press("l")
+        await pilot.pause()
+
+        # Should be on logs screen
+        assert isinstance(app.screen, LogsScreen)
+
+
+@pytest.mark.asyncio
+async def test_navigate_between_all_screens():
+    """
+    Test navigation flow between dashboard, inventory, and logs.
+
+    A final smoke tests that comprehensively tests all of the screen
+    in one single run, to ensure no state garbage causes issues.
+    """
+    app = ExosphereUi()
+    async with app.run_test() as pilot:
+        # Start on dashboard
+        assert isinstance(app.screen, DashboardScreen)
+        await pilot.pause()
+
+        # Go to inventory
+        await pilot.press("i")
+        await pilot.pause()
+        assert isinstance(app.screen, InventoryScreen)
+
+        # Go to logs
+        await pilot.press("l")
+        await pilot.pause()
+        assert isinstance(app.screen, LogsScreen)
+
+        # Back to dashboard
+        await pilot.press("d")
+        await pilot.pause()
+        assert isinstance(app.screen, DashboardScreen)
+
+        # Back to inventory to ensure we can navigate again
+        await pilot.press("i")
+        await pilot.pause()
+        assert isinstance(app.screen, InventoryScreen)

--- a/uv.lock
+++ b/uv.lock
@@ -505,6 +505,7 @@ dev = [
     { name = "poethepoet" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-json-ctrf" },
     { name = "pytest-mock" },
@@ -540,6 +541,7 @@ dev = [
     { name = "poethepoet", specifier = ">=0.33.1" },
     { name = "pyright", specifier = ">=1.1.400" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-json-ctrf", specifier = ">=0.3.5" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
@@ -1205,6 +1207,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The functional, integration tests for the TUI are done using the actual Textual testing framework, which implies a dependency on pytest-asyncio.

This so far serves mostly as a smoke test to ensure the TUI starts up, navigation works, and all modal Screens can be composed without throwing an exception.

Coupled with the recently added CI action to run the test suite against the minimum versions defined in pyproject.toml, this _would_ have caught the Textual version compatibility error. (I actually tested this very scenario).

This should ensure we at least have a basic catch all failure mode for TUI regressions in the future.