### PR TITLE
REPL: Refactor host completion to be dynamic

### DIFF
--- a/src/exosphere/commands/connections.py
+++ b/src/exosphere/commands/connections.py
@@ -10,6 +10,7 @@ from typing_extensions import Annotated
 
 from exosphere import app_config
 from exosphere.commands.utils import (
+    HostArgument,
     console,
     err_console,
     get_hosts_or_error,
@@ -56,6 +57,7 @@ def show(
             help="Hosts to show connection state for. If omitted, shows all hosts.",
             metavar="[HOSTS]...",
         ),
+        HostArgument(multiple=True),
     ] = None,
     active_only: Annotated[
         bool,
@@ -152,6 +154,7 @@ def close(
             help="Hosts to close connections for. If omitted, close all connections.",
             metavar="[HOSTS]...",
         ),
+        HostArgument(multiple=True),
     ] = None,
     verbose: Annotated[
         bool,

--- a/src/exosphere/commands/host.py
+++ b/src/exosphere/commands/host.py
@@ -15,7 +15,12 @@ from rich.text import Text
 from typing_extensions import Annotated
 
 from exosphere import app_config
-from exosphere.commands.utils import console, err_console, get_host_or_error
+from exosphere.commands.utils import (
+    HostArgument,
+    console,
+    err_console,
+    get_host_or_error,
+)
 from exosphere.objects import Host
 
 # Reuse the save function from the inventory command
@@ -143,7 +148,9 @@ def _display_updates_table(host: Host, security_only: bool) -> None:
 
 @app.command()
 def show(
-    name: Annotated[str, typer.Argument(help="Host from inventory to show")],
+    name: Annotated[
+        str, typer.Argument(help="Host from inventory to show"), HostArgument()
+    ],
     include_updates: Annotated[
         bool,
         typer.Option(
@@ -204,7 +211,9 @@ def show(
 
 @app.command()
 def discover(
-    name: Annotated[str, typer.Argument(help="Host from inventory to discover")],
+    name: Annotated[
+        str, typer.Argument(help="Host from inventory to discover"), HostArgument()
+    ],
 ) -> None:
     """
     Gather platform data for host.
@@ -239,7 +248,9 @@ def discover(
 
 @app.command()
 def refresh(
-    name: Annotated[str, typer.Argument(help="Host from inventory to refresh")],
+    name: Annotated[
+        str, typer.Argument(help="Host from inventory to refresh"), HostArgument()
+    ],
     full: Annotated[
         bool, typer.Option("--sync", "-s", help="Also sync package repositories")
     ] = False,
@@ -320,7 +331,9 @@ def refresh(
 
 @app.command()
 def ping(
-    name: Annotated[str, typer.Argument(help="Host from inventory to ping")],
+    name: Annotated[
+        str, typer.Argument(help="Host from inventory to ping"), HostArgument()
+    ],
 ) -> None:
     """
     Ping a specific host to check its reachability.

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -19,6 +19,7 @@ from typing_extensions import Annotated
 
 from exosphere import app_config
 from exosphere.commands.utils import (
+    HostArgument,
     console,
     err_console,
     get_hosts_or_error,
@@ -60,6 +61,7 @@ def discover(
         typer.Argument(
             help="Host(s) to discover, all if not specified", metavar="[HOST]..."
         ),
+        HostArgument(multiple=True),
     ] = None,
 ) -> None:
     """
@@ -136,6 +138,7 @@ def refresh(
         typer.Argument(
             help="Host(s) to refresh, all if not specified", metavar="[HOST]..."
         ),
+        HostArgument(multiple=True),
     ] = None,
 ) -> None:
     """
@@ -243,6 +246,7 @@ def ping(
         typer.Argument(
             help="Host(s) to ping, all if not specified", metavar="[HOST]..."
         ),
+        HostArgument(multiple=True),
     ] = None,
 ) -> None:
     """
@@ -322,6 +326,7 @@ def status(
         typer.Argument(
             help="Host(s) to show status for, all if not specified", metavar="[HOST]..."
         ),
+        HostArgument(multiple=True),
     ] = None,
 ) -> None:
     """

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -9,6 +9,7 @@ from rich.json import JSON
 from typing_extensions import Annotated
 
 from exosphere.commands.utils import (
+    HostArgument,
     console,
     err_console,
     get_hosts_or_error,
@@ -92,6 +93,7 @@ def generate(
             help="One or more hosts to include (all if not specified)",
             metavar="[HOST]...",
         ),
+        HostArgument(multiple=True),
     ] = None,
 ) -> None:
     """

--- a/src/exosphere/commands/sudo.py
+++ b/src/exosphere/commands/sudo.py
@@ -10,6 +10,7 @@ from rich.table import Table
 from typing_extensions import Annotated
 
 from exosphere import app_config, context
+from exosphere.commands.utils import HostArgument, HostOption
 from exosphere.data import ProviderInfo
 from exosphere.objects import Host
 from exosphere.providers.factory import PkgManagerFactory
@@ -158,7 +159,9 @@ def policy():
 
 @app.command()
 def check(
-    host: str = typer.Argument(help="Host to check security policies for"),
+    host: Annotated[
+        str, typer.Argument(help="Host to check security policies for"), HostArgument()
+    ],
 ):
     """
     Check the effective Sudo Policies for a given host.
@@ -310,6 +313,7 @@ def generate(
             rich_help_panel="Mandatory Options (mutually exclusive)",
             show_default=False,
         ),
+        HostOption(),
     ] = None,
     provider: Annotated[
         str | None,

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -10,6 +10,7 @@ as well as display bits around task execution, errors and status.
 
 import platform
 import sys
+from dataclasses import dataclass
 
 import typer
 from rich import box
@@ -31,6 +32,26 @@ STATUS_FORMATS = {
 
 console = Console()
 err_console = Console(stderr=True)
+
+
+@dataclass
+class HostArgument:
+    """
+    Annotation class for typer Host arguments for REPL completion.
+
+    Set multiple=True to allow completion of multiple hosts.
+    """
+
+    multiple: bool = False
+
+
+@dataclass
+class HostOption:
+    """
+    Annotation class for typer Host options for REPL completion.
+    """
+
+    pass
 
 
 def print_version() -> None:


### PR DESCRIPTION
Replace host completion definitions in repl module with dynamic extraction via custom Annotation classes on Typer commands.

HostArgument can specify multiple hosts, and HostOptions will derive its option name(s) from the Click object directly.

This replaces the previously hardcoded static declaration of host arguments and options with whether or not they are SINGLE or MULTIPLE, ensuring I won't forget to update it in the future.

The downside is that the completion logic for hosts now fully hinges on a custom Annotation class being specified in the Typer command signature, but I think that's an acceptable tradeoff.

Tests have been refactored with fixtures that simulate this to reflect the new structure.

Minor cleanups have been made to the REPL module as well, including, but not limited to:

- Fixing lazy imports for in-memory inventory fallback
- Splitting no command error checks for readability
- Adding missing typing annotations
- Simplifying code where getattr with a default value yields more readable and concise code.