### PR TITLE
API Docs: document HostState dataclass

### DIFF
--- a/docs/source/api/dataclasses.rst
+++ b/docs/source/api/dataclasses.rst
@@ -19,3 +19,8 @@ listed below.
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. autoclass:: exosphere.data.HostState
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This pull request adds new API documentation for the `HostState` dataclass. The change ensures that the class and its members are included in the generated documentation.