### PR TITLE
Add sudo failure error handling to requires_sudo

### DIFF
--- a/src/exosphere/providers/api.py
+++ b/src/exosphere/providers/api.py
@@ -6,13 +6,23 @@ well as helper functions and decorators to be used by package manager
 provider implementations.
 """
 
+import functools
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 
 from fabric import Connection
+from invoke.exceptions import AuthFailure
 
 from exosphere.data import Update
+from exosphere.errors import DataRefreshError
+
+_SUDO_AUTH_FAILURE_MESSAGE = (
+    "Sudo failed: "
+    "Ensure the user is configured with passwordless sudo. "
+    "You can use 'exosphere sudo generate' to produce a sudoers snippet for this host. "
+    "See: https://exosphere.readthedocs.io/en/stable/connections.html#id1"
+)
 
 
 def requires_sudo(func: Callable) -> Callable:
@@ -23,9 +33,21 @@ def requires_sudo(func: Callable) -> Callable:
     it requires sudo privileges to execute. You should add it to any
     method that requires elevated privileges, i.e. whenever you are
     using 'cx.sudo()' instead of 'cx.run()'.
+
+    Additionally, the decorator provides enhanced error handling for
+    sudo related failures, presenting a clear message about sudo policies
+    and sudoers configuration when an AuthFailure or related exception occurs.
     """
-    setattr(func, "__requires_sudo", True)
-    return func
+
+    @functools.wraps(func)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        try:
+            return func(*args, **kwargs)
+        except AuthFailure as e:
+            raise DataRefreshError(_SUDO_AUTH_FAILURE_MESSAGE) from e
+
+    setattr(wrapper, "__requires_sudo", True)
+    return wrapper
 
 
 class PkgManager(ABC):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,10 +1,85 @@
 import logging
 
 import pytest
+from invoke.exceptions import AuthFailure
 
 from exosphere.data import Update
 from exosphere.errors import DataRefreshError
 from exosphere.providers import Apt, Dnf, Pkg, PkgAdd, PkgManagerFactory, Yum
+from exosphere.providers.api import requires_sudo
+
+
+class TestRequiresSudoDecorator:
+    """
+    Tests for the requires_sudo decorator in isolation.
+    """
+
+    def test_sets_requires_sudo_attribute(self):
+        """
+        Ensure the decorator sets the __requires_sudo attribute on the wrapped function.
+        """
+
+        @requires_sudo
+        def some_method():
+            pass
+
+        assert getattr(some_method, "__requires_sudo", False) is True
+
+    def test_passthrough_on_success(self):
+        """
+        Ensure normal execution passes the return value through unchanged.
+        """
+
+        @requires_sudo
+        def some_method():
+            return "ok"
+
+        assert some_method() == "ok"
+
+    def test_auth_failure_raises_data_refresh_error(self, mocker):
+        """
+        Ensure AuthFailure raised by cx.sudo() is caught and re-raised as
+        DataRefreshError with an actionable message about sudoers configuration.
+        """
+        mock_result = mocker.MagicMock()
+
+        @requires_sudo
+        def some_method():
+            raise AuthFailure(result=mock_result, prompt="[sudo] password: ")
+
+        with pytest.raises(DataRefreshError) as exc_info:
+            some_method()
+
+        assert "sudo" in str(exc_info.value).lower()
+
+    def test_auth_failure_preserves_cause(self, mocker):
+        """
+        Ensure the original AuthFailure is chained as __cause__ on the
+        DataRefreshError so that tracebacks remain useful.
+        """
+        mock_result = mocker.MagicMock()
+        original = AuthFailure(result=mock_result, prompt="[sudo] password: ")
+
+        @requires_sudo
+        def some_method():
+            raise original
+
+        with pytest.raises(DataRefreshError) as exc_info:
+            some_method()
+
+        assert exc_info.value.__cause__ is original
+
+    def test_other_exceptions_are_not_intercepted(self):
+        """
+        Ensure unrelated exceptions propagate as-is.
+        """
+
+        @requires_sudo
+        def some_method():
+            raise ValueError("unrelated error")
+
+        with pytest.raises(ValueError, match="unrelated error"):
+            some_method()
 
 
 class TestPkgManagerFactory:


### PR DESCRIPTION
The decorator itself will catch and reword invoke AuthFailure exceptions to communicate that sudoers are not properly configured.

This improves the scenario where sudoers is not configured correctly and policy is set to NOPASSWD, instead of returning a generic DataRefreshError with an inscrutable invoke/paramiko error message.

Resolves the rest of #200 