### PR TITLE
setup: Do not rely on lsb-release for version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Managed system where issue occurs (if applicable):**
  - Platform [e.g. FreeBSD 14.1, RockyLinux 9, Debian Linux 12 etc]
+ - The output of `cat /etc/os-release` (if applicable, linux only)
 
 **Additional context**
 Add any other context about the problem here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "2.4.1"
+version = "2.4.2.dev0"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/setup/detect.py
+++ b/src/exosphere/setup/detect.py
@@ -30,6 +30,10 @@ def platform_detect(cx: Connection) -> HostInfo:
     Detect the platform of the remote system.
     Entry point for refreshing all platform details.
 
+    Linux detection in general depends on the presence of a well-formed
+    /etc/os-release file, which is a safe assumption for everything we
+    explicitly support that's not EOL'd.
+
     :param cx: Fabric Connection object
     :return: HostInfo object with platform details
     """
@@ -114,8 +118,6 @@ def flavor_detect(cx: Connection, platform_name: str) -> str:
 
     # Linux
     if platform_name == "linux":
-        # We're just going to query /etc/os-release directly.
-        # Using lsb_release would be better, but it's less available
         result_id = cx.run("grep ^ID= /etc/os-release", hide=True, warn=True)
         result_like_id = cx.run(
             "grep ^ID_LIKE= /etc/os-release",
@@ -125,7 +127,7 @@ def flavor_detect(cx: Connection, platform_name: str) -> str:
 
         if result_id.failed:
             raise DataRefreshError(
-                "Failed to detect OS flavor via lsb identifier.",
+                "Failed to detect OS flavor via os-release identifier.",
                 stderr=result_id.stderr,
                 stdout=result_id.stdout,
             )
@@ -187,36 +189,31 @@ def version_detect(cx: Connection, flavor_name: str) -> str:
     if flavor_name.lower() not in SUPPORTED_FLAVORS:
         raise UnsupportedOSError(f"Unsupported OS flavor: {flavor_name}")
 
-    # Debian/Ubuntu
-    if flavor_name in ["ubuntu", "debian"]:
-        result_version = cx.run("lsb_release -s -r", hide=True, warn=True)
+    # Linux flavors that rely on os-release metadata
+    # (which is all of them, at the time of writing)
+    if flavor_name in ["ubuntu", "debian", "rhel", "fedora"]:
+        result_version = None
 
-        if result_version.failed:
-            raise DataRefreshError(
-                "Failed to detect OS version via lsb_release.",
-                stderr=result_version.stderr,
-                stdout=result_version.stdout,
+        # Some systems (debian sid, for instance) don't provide VERSION_ID,
+        # So we fall back to VERSION_CODENAME in these cases.
+        # If neither work, we just err on the side of failure.
+        for version_key in ["VERSION_ID", "VERSION_CODENAME"]:
+            result_version = cx.run(
+                f"grep ^{version_key}= /etc/os-release", hide=True, warn=True
             )
 
-        return result_version.stdout.strip()
+            if not result_version.failed:
+                logger.debug("Found version using %s", version_key)
+                version_line = result_version.stdout.strip()
+                version_value = version_line.partition("=")[2].strip().strip("\"'")
 
-    # Redhat-likes
-    if flavor_name in ["rhel", "fedora"]:
-        result_version = cx.run(
-            "grep ^VERSION_ID= /etc/os-release", hide=True, warn=True
+                return version_value
+
+        raise DataRefreshError(
+            "Failed to detect OS version via os-release VERSION_ID or VERSION_CODENAME.",
+            stderr=result_version.stderr if result_version else "",
+            stdout=result_version.stdout if result_version else "",
         )
-
-        if result_version.failed:
-            raise DataRefreshError(
-                "Failed to detect OS version via os-release VERSION_ID.",
-                stderr=result_version.stderr,
-                stdout=result_version.stdout,
-            )
-
-        version_line = result_version.stdout.strip()
-        version_value = version_line.partition("=")[2].strip().strip("\"'")
-
-        return version_value.lower()
 
     # FreeBSD
     if flavor_name == "freebsd":

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -137,8 +137,8 @@ class TestDetection:
     @pytest.mark.parametrize(
         "flavor,stdout,expected",
         [
-            ("ubuntu", "20.04\n", "20.04"),
-            ("debian", "12\n", "12"),
+            ("ubuntu", 'VERSION_ID="20.04"\n', "20.04"),
+            ("debian", 'VERSION_ID="12"\n', "12"),
             ("rhel", 'VERSION_ID="8.3"\n', "8.3"),
             ("freebsd", "13.0-RELEASE-p4\n", "13.0-RELEASE-p4"),
             ("openbsd", "7.3\n", "7.3"),
@@ -157,6 +157,39 @@ class TestDetection:
         version = version_detect(connection, flavor)
 
         # Assert that the detected version is as expected
+        assert version == expected
+
+    @pytest.mark.parametrize(
+        "flavor,version_stdout,codename_stdout,expected",
+        [
+            ("debian", "", "VERSION_CODENAME=sid\n", "sid"),
+            ("ubuntu", "", "VERSION_CODENAME=noble\n", "noble"),
+            ("fedora", "", "VERSION_CODENAME=rawhide\n", "rawhide"),
+            ("rhel", "", "VERSION_CODENAME=beefymiracle\n", "beefymiracle"),
+        ],
+        ids=[
+            "debian",
+            "ubuntu",
+            "fedora",
+            "rhel",  # Unlikely, but hey. Coverage!
+        ],
+    )
+    def test_version_detect_codename_fallback(
+        self, connection, flavor, version_stdout, codename_stdout, expected
+    ) -> None:
+        """
+        Some systems may not provide VERSION_ID, so we fall back to
+        VERSION_CODENAME for os-release based Linux flavors.
+        (which is all of them at this time)
+        """
+        # Setup fixture with side effects
+        connection.run.side_effect = [
+            _run_return(True, version_stdout),
+            _run_return(False, codename_stdout),
+        ]
+
+        version = version_detect(connection, flavor)
+
         assert version == expected
 
     @pytest.mark.parametrize(
@@ -252,7 +285,7 @@ class TestDetection:
             _run_return(False, "Linux\n"),
             _run_return(False, 'ID="debian"\n'),
             _run_return(True, ""),  # no ID_LIKE
-            _run_return(False, "12\n"),
+            _run_return(False, 'VERSION_ID="12"\n'),
             _run_return(False, "apt\n"),
         ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "2.4.1"
+version = "2.4.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
lsb-release is mostly deprecated on Debian and its variants, and since 2022, it's simply a wrapper script around /etc/os-release.

We already use /etc/os-release for most of our platform detection, so the last remaining uses of lsb-release (mostly historical) have been replaced with parsing of /etc/os-release.

Additionally, codepaths for handling Debian-likes and Redhat-likes have been merged into a single process, since they no longer differ.

Fixes #244