### PR TITLE
Debian: Log APT warnings in provider operations

### DIFF
--- a/src/exosphere/providers/debian.py
+++ b/src/exosphere/providers/debian.py
@@ -50,6 +50,10 @@ class Apt(PkgManager):
             )
             return False
 
+        # Log warnings from apt-get if there was any stderr output.
+        if update.stderr:
+            self._log_apt_warn(update.stderr)
+
         self.logger.debug("Apt repositories synchronized successfully")
 
         return True
@@ -78,6 +82,10 @@ class Apt(PkgManager):
             # We're probably good, no updates available.
             self.logger.debug("No updates available or no matches in output.")
             return updates
+
+        # Log warnings from apt-get if there was any stderr output.
+        if raw_query.stderr:
+            self._log_apt_warn(raw_query.stderr)
 
         for line in raw_query.stdout.splitlines():
             line = line.strip()
@@ -151,3 +159,16 @@ class Apt(PkgManager):
             source=repo_source,
             security=is_security,
         )
+
+    def _log_apt_warn(self, lines: str) -> None:
+        """
+        Log warnings from APT stderr output.
+        We ignore empty lines and lines that do not begin with "W:"
+
+        :param lines: Stderr output to log.
+        """
+        for line in lines.splitlines():
+            line = line.strip()
+            if not line or not line.startswith("W: "):
+                continue
+            self.logger.warning("APT: %s", line)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -229,6 +229,30 @@ class TestAptProvider:
         assert updates[7].name == "big-patch"
         assert updates[7].security
 
+    def test_get_updates_logs_apt_warnings(self, mock_connection, caplog):
+        """
+        Test that non-fatal APT stderr output is logged as a warning.
+        """
+        apt = Apt()
+        mock_connection.run.return_value.stdout = (
+            "Inst dovecot-core [1:2.3.19.1+dfsg1-2.1+deb12u1] "
+            "(1:2.3.19.1+dfsg1-2.1+deb12u2 Debian:12.11/stable [amd64])"
+        )
+        mock_connection.run.return_value.stderr = (
+            "W: Unable to read /etc/apt/preferences.d/pin-dovecot - "
+            "open (13: Permission denied)"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="exosphere.providers.apt"):
+            updates = apt.get_updates(mock_connection)
+
+        assert len(updates) == 1
+        assert any("APT: W:" in message for message in caplog.messages)
+        assert any(
+            "Unable to read /etc/apt/preferences.d/pin-dovecot" in message
+            for message in caplog.messages
+        )
+
     def test_get_updates_no_updates(self, mock_pkg_output_no_updates):
         """
         Test the get_updates method of the Apt provider when no updates are available.


### PR DESCRIPTION
We now log warnings from the package manager stderr when they occur during successful provider operations. This is intended to help surface non-fatal issues that may be occuring on the system, such as wrong file permissions or missing metadata, which could be relevant to users and help with troubleshooting.

We do not yet have a mechanism for raising a status of "Completed but with warnings" or similar within Exosphere, but for now this is an improvement over silently ignoring these.

Resolves #243, at least partially, by making the issue surface in the runtime logs.