### PR TITLE
CI: Include docs in test-minimum action

### DIFF
--- a/.github/workflows/test-minimum.yml
+++ b/.github/workflows/test-minimum.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install lowest version of dependencies
+    - name: Install lowest versions of dependencies
       run: |
         python -m pip install uv
         uv sync --resolution lowest-direct
@@ -42,3 +42,8 @@ jobs:
       with:
         report-path: './.tests_report.json'
       if: always()
+    - name: Build docs with lowest versions of dependencies
+      env:
+        UV_RESOLUTION: lowest-direct
+      run: |
+        uv run poe docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "sphinx-lint>=1.0.0",
     "sphinx-tabs>=3.4.7",
     "sphinxcontrib-spelling>=8.0.1",
-    "sphinxcontrib-typer>=0.5.1",
+    "sphinxcontrib-typer>=0.7.2",
     "textual-dev>=1.7.0",
 ]
 


### PR DESCRIPTION
This ensures that regression in sphinx as versions progress are surfaced in a way that isn't a surprise.