### PR TITLE
Unify undiscovered display, fix dashboard bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "2.5.0.dev0"
+version = "2.5.0.dev1"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -433,7 +433,7 @@ def status(
     for host in hosts:
         # Prepare some rendering data for suffixes and placeholders
         stale_suffix = " [dim]*[/dim]" if host.is_stale else ""
-        unknown_status = "[dim](unknown)[/dim]"
+        undiscovered_status = "[dim](undiscovered)[/dim]"
         unsupported_status = "[dim](unsupported)[/dim]"
         empty_placeholder = "[dim]—[/dim]"
 
@@ -455,14 +455,15 @@ def status(
             "[bold green]Online[/bold green]" if host.online else "[red]Offline[/red]"
         )
 
-        # Handle platform info display with unsupported status
+        # Helper function to get platform info with appropriate
+        # handling for unsupported and undiscovered hosts
         def get_platform_info(value):
             if value:
                 return value
-            elif host.online and not host.supported:
+            elif not host.supported:
                 return unsupported_status
             else:
-                return unknown_status
+                return undiscovered_status
 
         # Construct table row for host
         row = [

--- a/src/exosphere/ui/dashboard.py
+++ b/src/exosphere/ui/dashboard.py
@@ -42,7 +42,7 @@ class HostWidget(Widget):
             # Version info
             if not self.host.flavor or not self.host.version:
                 # Differentiate between unsupported and undiscovered
-                if self.host.online and not self.host.supported:
+                if not self.host.supported:
                     version_text = f"[dim]{self.host.os} (unsupported)[/dim]"
                 else:
                     version_text = "[dim](Undiscovered)[/dim]"
@@ -77,7 +77,7 @@ class HostWidget(Widget):
         # Update version info, with unsupported/undiscovered status
         version_label = self.query_one(".host-version", Label)
         if not self.host.flavor or not self.host.version:
-            if self.host.online and not self.host.supported:
+            if not self.host.supported:
                 version_text = f"[dim]{self.host.os} (unsupported)[/dim]"
             else:
                 version_text = "[dim](Undiscovered)[/dim]"

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -197,12 +197,15 @@ class TestStatusCommand:
 
         mock_inventory.hosts = [host]
 
-        result = runner.invoke(inventory_module.app, ["status"])
+        # Widen the terminal so the "(undiscovered)" labels aren't truncated.
+        result = runner.invoke(
+            inventory_module.app, ["status"], env={"NO_COLOR": "1", "COLUMNS": "200"}
+        )
 
         assert result.exit_code == 0
         assert "host1" in result.output
-        assert "(unknown)" in result.output
-        assert result.output.count("(unknown)") == 3
+        assert "(undiscovered)" in result.output
+        assert result.output.count("(undiscovered)") == 3
 
         assert result.output.count("—") == 2  # No data for updates
         assert result.output.count("*") == 1  # No stale, except legend

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -179,6 +179,26 @@ def test_hostwidget_compose_online_unsupported(mocker, host_unsupported):
     assert "Online" in calls[3][0][0]
 
 
+def test_hostwidget_compose_offline_unsupported(mocker, host_unsupported):
+    """Test that HostWidget correctly reports unsupported offline hosts."""
+    host_unsupported.online = False
+
+    mock_container = mocker.MagicMock()
+    mock_label = mocker.MagicMock()
+
+    mocker.patch("exosphere.ui.dashboard.Container", return_value=mock_container)
+    label_mock = mocker.patch("exosphere.ui.dashboard.Label", return_value=mock_label)
+
+    widget = HostWidget(host_unsupported)
+    list(widget.compose())
+
+    calls = label_mock.call_args_list
+    # Must not regress to "(Undiscovered)" just because it's offline
+    assert "exotic-os (unsupported)" in calls[1][0][0]
+    assert "Undiscovered" not in calls[1][0][0]
+    assert "Offline" in calls[3][0][0]
+
+
 def test_hostwidget_init():
     """Test HostWidget initialization."""
     host = Host(name="test", ip="127.0.0.1")

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "2.5.0.dev0"
+version = "2.5.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },


### PR DESCRIPTION
Previously, the CLI used "(unknown)" as a placeholder for unavailability
of data within the CLI inventory status table.

This was an early design choice was made before the TUI was implemented,
and with the arrival of "unsupported" as a separate state, the TUI ended
up using different labels ("undiscovered" and "unsupported").

This change unifies the CLI and TUI displays by making the CLI use the
same verbiage for consistency.

Additionally, fixes a bug where, on the dashboard screen, an unsupported
host would fall back to "(unknown)" instead of "(unsupported)" when
offline, due to the way the distinction was made in the TUI handler
code. This handling logic has been unified to represent the same states.

A regression test has been added to cover this case.