### PR TITLE
Add Typer 0.26 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ license-files = [
 
 dependencies = [
     "fabric>=3.2.2",
-    "typer>=0.20.0, <0.26.0",
+    "typer>=0.20.0",
     "textual>=6.7.0",
     "pyyaml>=6.0.3",
     "platformdirs>=4.3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "2.5.0.dev2"
+version = "2.5.0.dev3"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/repl.py
+++ b/src/exosphere/repl.py
@@ -9,11 +9,12 @@ maintaining Rich output formatting.
 import inspect
 import logging
 import shlex
+import sys
 from collections.abc import Generator
 from enum import Enum
-from typing import Annotated, get_args, get_origin
+from typing import Annotated, cast, get_args, get_origin
 
-import click
+import typer
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.document import Document
@@ -23,12 +24,34 @@ from prompt_toolkit.shortcuts import CompleteStyle
 from rich.console import Console
 from rich.panel import Panel
 from typer import Context
+from typer.core import TyperCommand, TyperGroup
 
 from exosphere import app_config
 from exosphere import context as app_context
 from exosphere.commands.utils import HostArgument, HostOption
 
 logger = logging.getLogger(__name__)
+
+
+class _NoArgsIsHelpUnavailable(BaseException):
+    """
+    Sentinel exception for missing NoArgsIsHelpError
+
+    This exists as a fallback in case a future version of Typer, post
+    0.26, stops exposing NoArgsIsHelpError in the same module as typer.Exit.
+
+    It is never raised directly, but allows the module to import cleanly.
+    """
+
+
+# Typer 0.26+ vendored Click, and doesn't re-export NoArgsIsHelpError.
+# It however still lives in the same module as Exit. Since I don't love
+# relying on this kind of behavior too hard, we anchor off the public
+# symbol to resolve the class name, but we fallback to a sentinel to
+# degrade gracefully and catch this in CI if it ever changes.
+_NoArgsIsHelpError: type[BaseException] = getattr(
+    sys.modules[typer.Exit.__module__], "NoArgsIsHelpError", _NoArgsIsHelpUnavailable
+)
 
 
 class HostMatchMode(Enum):
@@ -48,6 +71,7 @@ type SubcommandHostMode = dict[str, HostMatchMode]
 type HostArgMetadata = dict[str, SubcommandHostMode]
 type SubcommandOptionNames = dict[str, list[str]]
 type HostOptionMetadata = dict[str, SubcommandOptionNames]
+type CommandNode = TyperGroup | TyperCommand
 
 
 class ExosphereCompleter(Completer):
@@ -67,7 +91,7 @@ class ExosphereCompleter(Completer):
     annotations (HostArgument and HostOption) at initialization time.
     """
 
-    def __init__(self, root_command: click.Command | None) -> None:
+    def __init__(self, root_command: TyperGroup | None) -> None:
         self.root_command = root_command
         self.commands = ["clear", "help", "exit", "quit"]
         if root_command:
@@ -80,7 +104,7 @@ class ExosphereCompleter(Completer):
         self.HOST_OPTION_COMMANDS = option_commands
 
     def _extract_host_metadata(
-        self, root_command: click.Command | None
+        self, root_command: TyperGroup | None
     ) -> tuple[HostArgMetadata, HostOptionMetadata]:
         """
         Extract host completion metadata from command annotations.
@@ -106,7 +130,7 @@ class ExosphereCompleter(Completer):
     def _extract_from_group(
         self,
         group_name: str,
-        group_cmd: click.Command,
+        group_cmd: TyperGroup,
         host_args: HostArgMetadata,
         host_options: HostOptionMetadata,
     ) -> None:
@@ -121,7 +145,7 @@ class ExosphereCompleter(Completer):
         self,
         group_name: str,
         cmd_name: str,
-        cmd: click.Command,
+        cmd: TyperCommand,
         host_args: HostArgMetadata,
         host_options: HostOptionMetadata,
     ) -> None:
@@ -139,7 +163,7 @@ class ExosphereCompleter(Completer):
         self,
         group_name: str,
         cmd_name: str,
-        cmd: click.Command,
+        cmd: TyperCommand,
         param: inspect.Parameter,
         host_args: HostArgMetadata,
         host_options: HostOptionMetadata,
@@ -171,7 +195,7 @@ class ExosphereCompleter(Completer):
                     host_options[group_name][cmd_name] = option_names
 
     def _get_option_names_from_param(
-        self, cmd: click.Command, param_name: str
+        self, cmd: TyperCommand, param_name: str
     ) -> list[str]:
         """Extract option names from Click command param."""
         for click_param in getattr(cmd, "params", []):
@@ -312,7 +336,7 @@ class ExosphereCompleter(Completer):
 
             yield from self._complete_host_names(current, sp, exclude=exclude)
 
-    def _is_flag_option(self, subsub: click.Command, option_name: str) -> bool:
+    def _is_flag_option(self, subsub: TyperCommand, option_name: str) -> bool:
         """
         Check if an option is a flag (doesn't take a value).
 
@@ -338,7 +362,7 @@ class ExosphereCompleter(Completer):
         return False
 
     def _get_choice_option_values(
-        self, subsub: click.Command, option_name: str
+        self, subsub: TyperCommand, option_name: str
     ) -> list[str] | None:
         """
         Return the valid values for a fixed-choice option, or None.
@@ -352,8 +376,10 @@ class ExosphereCompleter(Completer):
         for param in getattr(subsub, "params", []):
             if option_name in getattr(param, "opts", []):
                 param_type = getattr(param, "type", None)
-                if isinstance(param_type, click.Choice):
-                    return list(param_type.choices)
+                # Best effort check for Choice types, since Typer
+                # 0.26 vendors click, and doesn't export click.Choice
+                if getattr(param_type, "name", None) == "choice":
+                    return list(getattr(param_type, "choices", []))
                 return None
 
         return None
@@ -512,8 +538,12 @@ class ExosphereREPL:
         # Setup persistent history
         self.history = self._setup_history()
 
-        # Get the root command for executing subcommands
-        self.root_command = ctx.command if ctx.command else None
+        # Get the root command for executing subcommands.
+        # Typer statically types ctx.command as the base Command, but
+        # for a Typer app the root is always the TyperGroup it built.
+        self.root_command: TyperGroup | None = (
+            cast(TyperGroup, ctx.command) if ctx.command else None
+        )
 
         # Setup the specialized completer
         self.completer = ExosphereCompleter(self.root_command)
@@ -614,7 +644,7 @@ class ExosphereREPL:
 
         except ValueError as e:
             self.console.print(f"[red]Error parsing command: {e}[/red]")
-        except (SystemExit, click.exceptions.Exit):
+        except (SystemExit, typer.Exit):
             # Commands may exit, this is expected
             pass
         except EOFError:
@@ -666,11 +696,11 @@ class ExosphereREPL:
             with subcommand.make_context(command_name, args[1:]) as sub_ctx:
                 subcommand.invoke(sub_ctx)
 
-        except click.exceptions.Exit:
+        except typer.Exit:
             # Commands (including help) may exit, this is expected
             pass
 
-        except click.exceptions.NoArgsIsHelpError:
+        except _NoArgsIsHelpError:
             # Command was invoked with no arguments and displayed help
             self.console.print(f"[red]Command {command_name} requires arguments[/red]")
 
@@ -688,7 +718,7 @@ class ExosphereREPL:
             self.console.print(f"[red]Error executing {command_name}: {e}[/red]")
             logger.exception(f"Error executing command '{command_name}': {e}")
 
-    def _unhide_commands(self, command: click.Command) -> None:
+    def _unhide_commands(self, command: CommandNode) -> None:
         """
         Recursively unhide all subcommands for interactive mode.
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -4,13 +4,13 @@ Tests for the REPL module
 
 from typing import Annotated
 
-import click
 import pytest
+import typer
 from prompt_toolkit.history import FileHistory, InMemoryHistory
 from typer import Context
 
 from exosphere.commands.utils import HostArgument, HostOption
-from exosphere.repl import ExosphereCompleter, ExosphereREPL
+from exosphere.repl import ExosphereCompleter, ExosphereREPL, _NoArgsIsHelpError
 
 
 @pytest.fixture
@@ -247,13 +247,19 @@ class TestExosphereCompleter:
         """
         Test completion of values for a fixed-choice (Enum) option (e.g. --sort).
         """
-        import click
         from prompt_toolkit.completion import CompleteEvent
         from prompt_toolkit.document import Document
 
+        # We duck type ourselves a choice-like Mock since Typer no
+        # longer lets you use click.Choice directly.
+        # This matches how the REPL checks for it anyways.
+        choice_type = mocker.Mock()
+        choice_type.name = "choice"
+        choice_type.choices = ["host", "os", "flavor", "status"]
+
         param = mocker.Mock()
         param.opts = ["-o", "--sort"]
-        param.type = click.Choice(["host", "os", "flavor", "status"])
+        param.type = choice_type
         subsub = mocker.Mock()
         subsub.params = [param]
         sub = mocker.Mock()
@@ -1292,7 +1298,7 @@ class TestExosphereREPL:
         # Mock context manager for fake typer command
         # Ensure it raises NoArgsIsHelpError
         dummy_ctx = mocker.Mock()
-        mock_sub.invoke.side_effect = click.exceptions.NoArgsIsHelpError(dummy_ctx)
+        mock_sub.invoke.side_effect = _NoArgsIsHelpError(dummy_ctx)
 
         mock_command = mocker.Mock()
         mock_command.commands = {"foo": mock_sub}
@@ -1503,7 +1509,7 @@ class TestExosphereREPL:
         hidden_cmd.hidden = True
         hidden_cmd.commands = {}
 
-        hidden_cmd.make_context.side_effect = click.exceptions.Exit(0)
+        hidden_cmd.make_context.side_effect = typer.Exit(0)
 
         # Setup root command containing the hidden command
         root_cmd = mocker.MagicMock()
@@ -1533,7 +1539,7 @@ class TestExosphereREPL:
         parent_cmd.hidden = False
         parent_cmd.commands = {"save": hidden_subcmd}
 
-        parent_cmd.make_context.side_effect = click.exceptions.Exit(0)
+        parent_cmd.make_context.side_effect = typer.Exit(0)
 
         # Set up root command
         root_cmd = mocker.MagicMock()

--- a/tests/test_typer_smoketest.py
+++ b/tests/test_typer_smoketest.py
@@ -1,0 +1,222 @@
+"""
+Typer Library Contract Smoketests
+
+Since 0.26.0, Typer has vendored Click and does not expose some of the
+internals or Click objects we relied on to cover the gaps in the API.
+
+As a result, most of our code has been either ported to native Typer APIs,
+or in the many cases where this isn't possible, duck-typed or anchored off
+*assumptions* and (reasonable) expectations around what essentially is more
+or less leaking through the public API surface.
+
+Since this is more fragile than I'd like, and since the REPL is very much
+the centerpiece of the Exosphere UX, this test suite exists to validate
+these assumptions, preferably not against mocks, but against real Typer apps.
+
+Typer has signaled that the embedded Click surface may change in the future,
+and so the REPL deliberately duck-types or anchors off public symbols to
+potentially survive these changes, and is generally made to be defensive
+and to degrade gracefully if these assumptions break.
+
+Should this test suite go belly up on a Typer upgrade, this is a clear
+indicator that something went wrong or changed.
+
+The repository is setup to run the test suites (min, pin and latest)
+whenever Typer updates, so we will know early.
+
+"""
+
+import enum
+from typing import cast
+
+import pytest
+import typer
+from prompt_toolkit.history import InMemoryHistory
+from typer import Context
+from typer.core import TyperCommand, TyperGroup
+from typer.main import get_command
+
+from exosphere.repl import (
+    ExosphereCompleter,
+    ExosphereREPL,
+    _NoArgsIsHelpError,
+    _NoArgsIsHelpUnavailable,
+)
+
+
+class SortField(str, enum.Enum):
+    """Stand-in for an Enum-backed option (like the real --sort)"""
+
+    host = "host"
+    os = "os"
+    flavor = "flavor"
+    status = "status"
+
+
+@pytest.fixture
+def sample_app():
+    """
+    A sample Typer app shaped like Exosphere, more or less
+
+    - Two groups with no_args_is_help=True
+    - One leaf with a required arg + bool flag + value option
+    - One leaf with an Enum option
+
+    Returns a tuple of (app, recorder) where the app is the Typer app,
+    and recorder is a list of callback invocations.
+    """
+    recorder: list = []
+
+    root = typer.Typer()
+    host_app = typer.Typer(no_args_is_help=True)
+    inv_app = typer.Typer(no_args_is_help=True)
+    root.add_typer(host_app, name="host")
+    root.add_typer(inv_app, name="inventory")
+
+    @host_app.command()
+    def show(name: str, updates: bool = False, port: int = 22) -> None:
+        recorder.append(("show", name, updates, port))
+
+    @inv_app.command()
+    def status(sort: SortField = SortField.host) -> None:
+        recorder.append(("status", sort))
+
+    return root, recorder
+
+
+def _make_repl(app, mocker) -> ExosphereREPL:
+    """
+    Build a REPL bound to a real command tree
+
+    History component is explicitly subbed for InMemoryHistory to avoid
+    filesystem I/O in tests, or side effects.
+    """
+    mocker.patch.object(ExosphereREPL, "_setup_history", return_value=InMemoryHistory())
+    ctx = mocker.Mock(spec=Context)
+    ctx.command = get_command(app)
+    return ExosphereREPL(ctx)
+
+
+# Narrow get_command() to TyperGroups, avoids having to scatter casts
+# everywhere through the tests.
+def _root(app) -> TyperGroup:
+    return cast(TyperGroup, get_command(app))
+
+
+def _group(parent: TyperGroup, name: str) -> TyperGroup:
+    return cast(TyperGroup, parent.commands[name])
+
+
+def _leaf(parent: TyperGroup, name: str) -> TyperCommand:
+    return cast(TyperCommand, parent.commands[name])
+
+
+class TestTyperContract:
+    def test_noargsishelp_symbol_resolves(self) -> None:
+        """
+        Ensure NoArgsIsHelpError resolves and lives in the expected Exit module.
+
+        If typer removes or relocates it, the REPL falls back to the
+        unraisable sentinel, which we can check for.
+        """
+        assert _NoArgsIsHelpError is not _NoArgsIsHelpUnavailable
+        assert issubclass(_NoArgsIsHelpError, BaseException)
+        assert _NoArgsIsHelpError.__name__ == "NoArgsIsHelpError"
+
+    def test_command_node_types_match_real_tree(self, sample_app) -> None:
+        """
+        Ensure the command node types match the real Typer tree.
+        """
+        root, _ = sample_app
+        root_cmd = _root(root)
+        host = _group(root_cmd, "host")
+        show = _leaf(host, "show")
+
+        assert isinstance(root_cmd, TyperGroup)
+        assert isinstance(host, TyperGroup)
+        assert isinstance(show, TyperCommand)
+        # Groups are not leaves and vice versa: the union is genuinely needed.
+        assert not isinstance(show, TyperGroup)
+
+    def test_enum_option_is_introspectable_as_choice(self, sample_app) -> None:
+        """
+        Ensure an Enum option is detectable as a choice-like param for tab completion
+
+        (previously handled through click.Choice)
+        """
+        root, _ = sample_app
+        root_cmd = _root(root)
+        status = _leaf(_group(root_cmd, "inventory"), "status")
+        completer = ExosphereCompleter(root_cmd)
+
+        values = completer._get_choice_option_values(status, "--sort")
+        assert values == ["host", "os", "flavor", "status"]
+
+    def test_bool_flag_is_introspectable(self, sample_app) -> None:
+        """
+        Ensure a bool option is detectable as a flag for tab completion
+        """
+        root, _ = sample_app
+        root_cmd = _root(root)
+        show = _leaf(_group(root_cmd, "host"), "show")
+        completer = ExosphereCompleter(root_cmd)
+
+        assert completer._is_flag_option(show, "--updates") is True
+        assert completer._is_flag_option(show, "--port") is False
+
+    def test_help_raises_typer_exit_and_is_swallowed(
+        self, sample_app, mocker, capsys
+    ) -> None:
+        """
+        Ensure invoking --help exits via typer.Exit and is caught by the REPL.
+
+        This is important because otherwise it will get caught by the
+        REPL's catch-all and treated as a dirty, filthy, shitty error.
+        This is not something you want out of --help as behavior.
+        """
+        root, _ = sample_app
+        repl = _make_repl(root, mocker)
+
+        repl._execute_typer_command(["host", "show", "--help"])
+        out = capsys.readouterr().out
+
+        assert "Error executing" not in out
+        assert "--help" in out or "Usage" in out
+
+    def test_no_args_group_appends_requires_arguments(
+        self, sample_app, mocker, capsys
+    ) -> None:
+        """
+        Ensure invoking a no_args_is_help group with no subcommand behaves
+
+        We would expect typer to print the help for the group AND raise
+        NoArgsIsHelpError (which is a Click exception), which is how
+        the REPL detects this case and appends the "requires argument"
+        message to the user-facing output.
+
+        This test guards against Typer changing this mechanism, regardless
+        of *how* -- it doesn't matter. If the "require arguments" line
+        stops working, this fails.
+        """
+        root, _ = sample_app
+        repl = _make_repl(root, mocker)
+
+        repl._execute_typer_command(["host"])
+        out = capsys.readouterr().out
+
+        assert "requires arguments" in out  # the REPL's message (ours)
+        assert "Usage" in out or "show" in out  # Typer did its job
+
+    def test_dispatch_runs_command_callback(self, sample_app, mocker) -> None:
+        """
+        Ensure ctx.command is the group and dispatches
+
+        We want to ensure that the leaf callback is actually dispatched with
+        the parsed args, which is the whole point.
+        """
+        root, recorder = sample_app
+        repl = _make_repl(root, mocker)
+
+        repl._execute_typer_command(["host", "show", "web01", "--updates"])
+
+        assert recorder == [("show", "web01", True, 22)]

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "2.5.0.dev2"
+version = "2.5.0.dev3"
 source = { editable = "." }
 dependencies = [
     { name = "fabric" },

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.1.0" },
     { name = "textual", specifier = ">=6.7.0" },
     { name = "textual-serve", marker = "extra == 'web'", specifier = ">=1.1.3" },
-    { name = "typer", specifier = ">=0.20.0,<0.26.0" },
+    { name = "typer", specifier = ">=0.20.0" },
 ]
 provides-extras = ["web"]
 
@@ -1726,15 +1726,15 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-typer"
-version = "0.8.1"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/17/7e07799e1df369c170e747f8866b80563ff88d385f14304f8891a9f0fe4e/sphinxcontrib_typer-0.8.1.tar.gz", hash = "sha256:223016757b3ab1995971fce048ed5e939b4fd45ca0c255e320e0f87d04dbf9ef", size = 228669, upload-time = "2026-03-06T00:43:01.459Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/e5/a3463123d69ae431ce8708cab92de0434012bd3d1f4d8e3ea82fc1a5ed82/sphinxcontrib_typer-0.9.0.tar.gz", hash = "sha256:480175de4f0ee280cde438f830996cbc7f1f5d8838157bbe9f5dc7894615a002", size = 168792, upload-time = "2026-06-02T00:01:04.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/30/715e975d6e0b47979d37dab9fca05d8a178e45384d6f44fbf7ec76368220/sphinxcontrib_typer-0.8.1-py3-none-any.whl", hash = "sha256:869a69caf367af94e4acf2cfd62ce8b87faa02831c3d68c5fb1c96cc6b5dac2a", size = 14711, upload-time = "2026-03-06T00:42:59.781Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/1e/eca6d5b3bc072a8c02cd1ccdd558e75aec7f19f70e91d87fdd93a46ab904/sphinxcontrib_typer-0.9.0-py3-none-any.whl", hash = "sha256:f171000b4000f392517735855e5915ffc08afaf6b6d127116f239c4715a75f5c", size = 14821, upload-time = "2026-06-02T00:01:03.431Z" },
 ]
 
 [[package]]
@@ -1801,17 +1801,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This removes the reliance on Click internals entirely -- at least
strictly speaking.
The Typer API still has gaps that we previously covered with Click
objects where applicable.
    
Since Typer 0.26 vendored click, and outright announced intent to break
the internals as they please, some workarounds are necessary.
    
Most of the click API surface we used has been migrated to native
Typer APIs, but some is still missing, and I have zero desire to import
private internal APIs from typer, which is fragile.
    
So a good middle ground has been to duck type most of it, anchoring
on public APIs where available. Sentinels and nice graceful degradation
have been provided to avoid straight up runtime errors if Typer ruins
christmas on a new release one day.

Additionally, a smoketest suite has been added to cover the critical
assumptions we make about Typer's behavior in the REPL, which guards
against future breakage.
    
I don't LOVE this, but it is what it is, and will do until a better
solution presents itself, if ever.

Fixes (mainly) #277
