### PR TITLE
Improve UI logging, cleanup loglevels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev0"
+version = "3.0.0.dev1"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/inventory.py
+++ b/src/exosphere/inventory.py
@@ -437,7 +437,7 @@ class Inventory:
             if exc:
                 self.logger.error("Failed to discover host %s: %s", host.name, exc)
             else:
-                self.logger.info("Host %s discovered successfully", host.name)
+                self.logger.debug("Host %s discovered successfully", host.name)
 
         self.logger.info("All hosts discovered")
 
@@ -458,7 +458,7 @@ class Inventory:
                     "Failed to sync repositories for host %s: %s", host.name, exc
                 )
             else:
-                self.logger.info("Package repositories synced for host %s", host.name)
+                self.logger.debug("Package repositories synced for host %s", host.name)
 
         self.logger.info("Package repositories synced for all hosts")
 
@@ -480,7 +480,7 @@ class Inventory:
                     "Failed to refresh updates for host %s: %s", host.name, exc
                 )
             else:
-                self.logger.info("Updates refreshed for host %s", host.name)
+                self.logger.debug("Updates refreshed for host %s", host.name)
 
         self.logger.info("Updates refreshed for all hosts")
 
@@ -502,7 +502,7 @@ class Inventory:
                 self.logger.error("Failed to ping host %s: %s", host.name, exc)
             else:
                 status = "offline" if not online else "online"
-                self.logger.info("Host %s is %s", host.name, status)
+                self.logger.debug("Host %s is %s", host.name, status)
 
         self.logger.info("Pinged all hosts")
 

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -197,7 +197,9 @@ class Host:
 
         # Instantiate concrete package manager if defined
         if self.package_manager and self.supported:
-            self._pkginst = PkgManagerFactory.create(self.package_manager)
+            self._pkginst = PkgManagerFactory.create(
+                self.package_manager, host_name=self.name
+            )
         else:
             self._pkginst = None
 
@@ -479,7 +481,9 @@ class Host:
         self.package_manager = platform_info.package_manager
 
         if self.package_manager:
-            self._pkginst = PkgManagerFactory.create(self.package_manager)
+            self._pkginst = PkgManagerFactory.create(
+                self.package_manager, host_name=self.name
+            )
             self.logger.debug(
                 "Using concrete package manager %s.%s for %s",
                 self._pkginst.__class__.__module__,

--- a/src/exosphere/providers/api.py
+++ b/src/exosphere/providers/api.py
@@ -9,13 +9,29 @@ provider implementations.
 import functools
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, MutableMapping
+from typing import Any
 
 from fabric import Connection
 from invoke.exceptions import AuthFailure
 
 from exosphere.data import Update
 from exosphere.errors import SUDO_AUTH_FAILURE_MESSAGE, DataRefreshError
+
+
+class _HostLogAdapter(logging.LoggerAdapter):
+    """
+    Logger adapter that prefixes messages with a host name.
+    """
+
+    def __init__(self, logger: logging.Logger, host_name: str) -> None:
+        super().__init__(logger, {"host": host_name})
+        self._host_name = host_name
+
+    def process(
+        self, msg: Any, kwargs: MutableMapping[str, Any]
+    ) -> tuple[Any, MutableMapping[str, Any]]:
+        return f"[{self._host_name}] {msg}", kwargs
 
 
 def requires_sudo(func: Callable) -> Callable:
@@ -81,10 +97,20 @@ class PkgManager(ABC):
         Initialize the Package Manager.
         """
 
-        # Setup logging
-        self.logger = logging.getLogger(
+        # Setup logging - base logger is per-provider class.
+        # The bind_host() method can later wrap it to add a host prefix
+        self._base_logger = logging.getLogger(
             f"exosphere.providers.{self.__class__.__name__.lower()}"
         )
+        self.logger: logging.Logger | logging.LoggerAdapter = self._base_logger
+
+    def bind_host(self, host_name: str) -> None:
+        """
+        Attach host context to this provider's logger.
+
+        :param host_name: Name of the host this provider instance serves.
+        """
+        self.logger = _HostLogAdapter(self._base_logger, host_name)
 
     @abstractmethod
     def reposync(self, cx: Connection) -> bool:

--- a/src/exosphere/providers/factory.py
+++ b/src/exosphere/providers/factory.py
@@ -38,15 +38,22 @@ class PkgManagerFactory:
         return PkgManagerFactory._REGISTRY.copy()
 
     @staticmethod
-    def create(name: str) -> PkgManager:
+    def create(name: str, host_name: str | None = None) -> PkgManager:
         """
         Create a package manager instance based on the provided name.
 
         :param name: Name of the package manager (e.g., 'apt').
+        :param host_name: Optional host name to bind for log context, so
+                          the provider's log lines are prefixed with it
         :return: An instance of the specified package manager.
         """
         if name not in PkgManagerFactory._REGISTRY:
             raise ValueError(f"Unsupported package manager: {name}")
 
         pkg_impl = PkgManagerFactory._REGISTRY[name]
-        return pkg_impl()
+        instance = pkg_impl()
+
+        if host_name:
+            instance.bind_host(host_name)
+
+        return instance

--- a/src/exosphere/providers/redhat.py
+++ b/src/exosphere/providers/redhat.py
@@ -203,7 +203,7 @@ class Dnf(PkgManager):
                 name, version, source = parsed
                 updates.append(name)
 
-        self.logger.info("Found %d security updates", len(updates))
+        self.logger.debug("Found %d security updates", len(updates))
         return updates
 
     def _parse_line(self, line: str) -> tuple[str, str, str] | None:

--- a/src/exosphere/ui/elements.py
+++ b/src/exosphere/ui/elements.py
@@ -255,7 +255,7 @@ class ProgressScreen(Screen[TaskOutcome]):
                     logger.warning("Task was cancelled, stopping progress update.")
                     break
 
-            logger.info("Finished running %s.", self.operation.value)
+            logger.debug("Finished running %s.", self.operation.value)
 
             # Attempt to serialize state if autosave is enabled, unless
             # the operation is stateless or states otherwise

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -599,7 +599,7 @@ class InventoryScreen(DataScreen):
                 self.current_filter = filter_mode
                 self.refresh_rows("filter")
                 self._update_status_bar()
-                logger.info("Applied filter: %s", filter_mode)
+                logger.debug("Applied filter: %s", filter_mode)
 
         self.app.push_screen(FilterScreen(), handle_filter_selection)
 
@@ -623,7 +623,7 @@ class InventoryScreen(DataScreen):
             self.refresh_rows("sort")
             self._update_status_bar()
             field_name = field.value if field is not None else "default"
-            logger.info("Applied sort: %s (reverse=%s)", field_name, reverse)
+            logger.debug("Applied sort: %s (reverse=%s)", field_name, reverse)
 
         self.app.push_screen(
             SortScreen(self.current_sort, self.sort_reverse), handle_sort_selection

--- a/src/exosphere/ui/logs.py
+++ b/src/exosphere/ui/logs.py
@@ -6,6 +6,7 @@ import logging
 import threading
 from typing import cast
 
+from rich.markup import escape
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.screen import Screen
@@ -33,7 +34,10 @@ class RichLogFormatter(logging.Formatter):
         timestamp = self.formatTime(record, self.datefmt)
         logger_name = record.name
         level_name = record.levelname
-        message = record.getMessage()
+
+        # Escape rich markup in the log message
+        # Log strings should never contained unescaped markup.
+        message = escape(record.getMessage())
 
         # Strip "exosphere." prefix to save space
         if logger_name.startswith("exosphere."):

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1161,7 +1161,7 @@ class TestInventory:
         # Get corresponding method to call on Inventory
         target_method = getattr(inventory, f"{method_name}_all")
 
-        with caplog.at_level("INFO"):
+        with caplog.at_level("DEBUG"):
             target_method()
 
         assert any(success_log in m for m in caplog.messages)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1458,7 +1458,7 @@ class TestHostStateSerialization:
 
         host.from_state(state)
 
-        mock_factory.assert_called_once_with("apt")
+        mock_factory.assert_called_once_with("apt", host_name="test_host")
         assert host._pkginst == fake_pkginst
 
     def test_from_state_no_pkginst_when_not_supported(self, mocker):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -121,6 +121,55 @@ class TestPkgManagerFactory:
         assert PkgManagerFactory.get_registry()["apt"] != "modified"
 
 
+class TestHostLogBinding:
+    """
+    Tests for binding host context onto a provider's logger, so log
+    lines can be traced back to the host that produced them.
+    """
+
+    def test_create_with_host_prefixes_messages(self, caplog):
+        """A provider created for a host prefixes its log lines with [host]."""
+        pkg = PkgManagerFactory.create("apt", host_name="web1")
+
+        with caplog.at_level(logging.WARNING, logger="exosphere.providers.apt"):
+            pkg.logger.warning("Spaghetti is falling out of pockets!")
+
+        assert (
+            caplog.records[-1].getMessage()
+            == "[web1] Spaghetti is falling out of pockets!"
+        )
+
+    def test_create_without_host_has_no_prefix(self, caplog):
+        """A provider created without a host name logs unprefixed."""
+        pkg = PkgManagerFactory.create("apt")
+
+        with caplog.at_level(logging.WARNING, logger="exosphere.providers.apt"):
+            pkg.logger.warning("Spaghetti successfully pocketed")
+
+        assert caplog.records[-1].getMessage() == "Spaghetti successfully pocketed"
+
+    def test_bind_host_wraps_existing_instance(self, caplog):
+        """bind_host attaches the prefix to an already-constructed provider."""
+        pkg = Apt()
+        pkg.bind_host("compute3")
+
+        with caplog.at_level(logging.WARNING, logger="exosphere.providers.apt"):
+            pkg.logger.warning("The spaghetti was late to the party")
+
+        assert (
+            caplog.records[-1].getMessage()
+            == "[compute3] The spaghetti was late to the party"
+        )
+
+    def test_bound_logger_keeps_per_class_name(self):
+        """None of this affects or changes the logger name"""
+        pkg = PkgManagerFactory.create("apt", host_name="web1")
+
+        # Outer logger is the logging adapter, inner is logger
+        assert isinstance(pkg.logger, logging.LoggerAdapter)
+        assert pkg.logger.logger.name == "exosphere.providers.apt"
+
+
 class TestAptProvider:
     @pytest.fixture
     def mock_connection(self, mocker):

--- a/tests/ui/test_logs.py
+++ b/tests/ui/test_logs.py
@@ -1,10 +1,12 @@
+import io
 import logging
 import threading
 
 import pytest
+from rich.console import Console
 from textual.widgets import RichLog
 
-from exosphere.ui.logs import LogsScreen, UILogHandler
+from exosphere.ui.logs import LogsScreen, RichLogFormatter, UILogHandler
 
 
 @pytest.fixture
@@ -33,6 +35,56 @@ def mock_app(mocker):
 def clear_log_buffer():
     """Clear the log buffer before each test to avoid test interference."""
     UILogHandler.clear_buffer()
+
+
+class TestRichLogFormatter:
+    """Tests for the RichLogFormatter."""
+
+    @staticmethod
+    def _make_record(message: str, level: int = logging.WARNING) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="exosphere.providers.apt",
+            level=level,
+            pathname=__file__,
+            lineno=1,
+            msg=message,
+            args=(),
+            exc_info=None,
+        )
+
+    @staticmethod
+    def _render(formatted: str) -> str:
+        """
+        Render markup the way the RichLog widget (markup=True) would.
+
+        We (ab)use a Rich Console to achieve this outcome.
+        """
+        buffer = io.StringIO()
+        console = Console(file=buffer, width=200, color_system=None, markup=True)
+
+        console.print(formatted)
+
+        return buffer.getvalue()
+
+    def test_bracketed_message_survives_markup_rendering(self):
+        """Brackets must come out as literals, not swallowed"""
+        record = self._make_record(
+            "Spaghetti-x86 [arm64] for (pockets3), got [sudo] prompt:"
+        )
+        out = self._render(RichLogFormatter().format(record))
+
+        assert "[arm64]" in out
+        assert "[sudo] prompt:" in out
+        assert "(pockets3)" in out
+
+    def test_log_formatting_still_applies(self):
+        """Deliberate formatting in non message elemnts should remain"""
+        formatted = RichLogFormatter().format(self._make_record("SPAGHETT!"))
+        level_color = RichLogFormatter.LEVEL_COLORS["WARNING"]
+
+        # The deliberate level-coloring markup is present and active (un-escaped).
+        assert f"[{level_color}]" in formatted
+        assert f"\\[{level_color}]" not in formatted
 
 
 class TestUILogHandler:

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev0"
+version = "3.0.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
This PR accomplishes a few things:

- Package Manager Providers now prefix the host the message was emitted from into their message. This setup is handled by the PkgManagerFactory, and has essentially 0 API surface change
- Fixes an issue where the UI log renderer would interpret strings with brackets as Rich markup, and swallow them and/or introduce unintended side effects. The RichLogFormatter now correctly escapes the message part, keeping the rest of its fields intact to maintain colors.
- A bunch of extraneous messages have been downgraded from INFO level to DEBUG level, as they are not particularly helpful at runtime. I've kept aggregates and system actions in it for now, but this is a good first pass.