### PR TITLE
Improve CLI help formatting and validation logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev1"
+version = "3.0.0.dev2"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/cli.py
+++ b/src/exosphere/cli.py
@@ -11,6 +11,8 @@ and acts as the CLI entrypoint for the application.
 import logging
 
 from cyclopts import App
+from cyclopts.help import DefaultFormatter
+from cyclopts.help.specs import PanelSpec
 
 from exosphere import __version__, app_config
 from exosphere.commands import (
@@ -48,6 +50,9 @@ Run without arguments to start the interactive mode.
 """
 
 
+# Help panel formatter to use across the app
+HELP_FORMATTER = DefaultFormatter(panel_spec=PanelSpec(border_style="dim"))
+
 # Setup the root CLI app
 app = App(
     name="exosphere",
@@ -57,19 +62,27 @@ app = App(
     version_format="rich",
     version_flags=["--version", "-V"],
     error_formatter=error_formatter,  # Custom formatter
+    help_formatter=HELP_FORMATTER,
     console=console,
     error_console=err_console,
 )
 
 # Setup commands from modules
-app.command(inventory.app)
-app.command(host.app)
-app.command(connections.app)
-app.command(ui.app)
-app.command(config.app)
-app.command(report.app)
-app.command(sudo.app)
-app.command(version.app)
+for subapp in (
+    inventory.app,
+    host.app,
+    connections.app,
+    ui.app,
+    config.app,
+    report.app,
+    sudo.app,
+    version.app,
+):
+    # The REPL calls help directly on subapps at times, so we
+    # explicitly set the help formatter on them for consistency.
+    # Other scenarios inherit from the root app.
+    app.command(subapp)
+    subapp.help_formatter = HELP_FORMATTER
 
 
 def start_interactive() -> None:

--- a/src/exosphere/cli.py
+++ b/src/exosphere/cli.py
@@ -10,7 +10,7 @@ and acts as the CLI entrypoint for the application.
 
 import logging
 
-from cyclopts import App
+from cyclopts import App, Group
 from cyclopts.help import DefaultFormatter
 from cyclopts.help.specs import PanelSpec
 
@@ -83,6 +83,12 @@ for subapp in (
     # Other scenarios inherit from the root app.
     app.command(subapp)
     subapp.help_formatter = HELP_FORMATTER
+
+# Force root --help and --version flags to be part of the parameters
+# group instead of the commands one - this preserves previous behavior
+_root_flags_group = Group("Parameters")
+for flag in ("--help", "--version"):
+    app[flag].group = _root_flags_group
 
 
 def start_interactive() -> None:

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -5,7 +5,7 @@ Inventory command module
 import logging
 from typing import Annotated
 
-from cyclopts import App, Parameter
+from cyclopts import App, Group, Parameter, validators
 from rich import box
 from rich.panel import Panel
 from rich.progress import (
@@ -21,6 +21,7 @@ from rich.table import Table
 from exosphere import app_config
 from exosphere.commands.utils import (
     HostArg,
+    arg_requires_arg,
     console,
     err_console,
     get_hosts_or_all,
@@ -293,17 +294,46 @@ def ping(*names: HostArg) -> int:
     return 0
 
 
+STATUS_FILTER_GROUP = Group(
+    "Filtering Options", validator=validators.mutually_exclusive
+)
+STATUS_SORT_GROUP = Group(
+    "Sorting Options", validator=arg_requires_arg("reverse", "sort")
+)
+
+
 @app.command(synonym=["list", "show"])
 def status(
     *names: HostArg,
     updates_only: Annotated[
-        bool, Parameter(name=["--updates-only", "-u"], negative="")
+        bool,
+        Parameter(
+            name=["--updates-only", "-u"], negative="", group=STATUS_FILTER_GROUP
+        ),
     ] = False,
     security_only: Annotated[
-        bool, Parameter(name=["--security-only", "-s"], negative="")
+        bool,
+        Parameter(
+            name=["--security-only", "-s"],
+            negative="",
+            group=STATUS_FILTER_GROUP,
+        ),
     ] = False,
-    sort: Annotated[SortField | None, Parameter(name=["--sort", "-o"])] = None,
-    reverse: Annotated[bool, Parameter(name=["--reverse", "-r"], negative="")] = False,
+    sort: Annotated[
+        SortField | None,
+        Parameter(
+            name=["--sort", "-o"],
+            group=STATUS_SORT_GROUP,
+        ),
+    ] = None,
+    reverse: Annotated[
+        bool,
+        Parameter(
+            name=["--reverse", "-r"],
+            negative="",
+            group=STATUS_SORT_GROUP,
+        ),
+    ] = False,
     full: Annotated[bool, Parameter(name=["--full", "-f"], negative="")] = False,
 ) -> int:
     """
@@ -313,9 +343,9 @@ def status(
     in the inventory, including their package update counts, their
     online status and whether or not the data is stale.
 
-    Output can be filtered to only show hosts with pending
-    updates or security updates. Filtering for security updates
-    implies filtering for updates as well.
+    Output can be filtered to show only hosts with pending updates
+    (`--updates-only`) or only those with pending security updates
+    (`--security-only`). These two filters are mutually exclusive.
 
     Output can also be sorted by any column with `--sort`, optionally
     reversed with `--reverse`. Sorting by 'version' groups hosts by
@@ -336,7 +366,7 @@ def status(
     updates_only
         Show only hosts with pending updates
     security_only
-        Show only hosts with pending security updates (implies `--updates-only`)
+        Show only hosts with pending security updates
     sort
         Sort the table by the given column
     reverse
@@ -353,11 +383,11 @@ def status(
     if hosts is None:
         return 1  # Input error: no hosts to operate on
 
-    # Map the active flags to a FilterMode and table title.
-    # Note: security_only implies updates_only as they're a subset,
-    # so it effectively takes precedence here.
+    # Map the active filter flag to a FilterMode and table title.
+    # --updates-only and --security-only are mutually exclusive (enforced by
+    # the Filtering Options group validator), so at most one is set here.
     match (updates_only, security_only):
-        case (_, True):
+        case (False, True):
             filter_mode = FilterMode.SECURITY_ONLY
             table_suffix = "(security updates only)"
         case (True, False):
@@ -373,12 +403,9 @@ def status(
         console.print(Panel.fit("No hosts matching requested criteria."))
         return 3  # No matches for filtering
 
+    # The validator prevents --reverse without --sort
     if sort is not None:
         hosts = inventory.sort_hosts(sort, hosts=hosts, reverse=reverse)
-    elif reverse:
-        err_console.print(
-            "[yellow]Warning: --reverse has no effect without --sort[/yellow]"
-        )
 
     # Iterates through all hosts in the inventory and render a nice
     # Rich table with their properties and status. The sortable column

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -127,11 +127,11 @@ def refresh(
     Connects to hosts in the inventory and retrieves pending package
     updates.
 
-    If --discover is specified, the platform information (Operating
+    If `--discover` is specified, the platform information (Operating
     System flavor, version, package manager) will also be refreshed.
     Also refreshes the online status in the process.
 
-    If --sync is specified, the package repositories will also be synced.
+    If `--sync` is specified, the package repositories will also be synced.
 
     Syncing the package repositories involves invoking whatever mechanism
     the package manager uses to achieve this, and can be a very expensive
@@ -139,7 +139,7 @@ def refresh(
     with a handful of slow hosts.
 
     By default, only the progress bar is shown during the operation.
-    If --verbose is specified, the name and completion status of each host
+    If `--verbose` is specified, the name and completion status of each host
     will be shown in real time.
 
     Parameters
@@ -317,15 +317,15 @@ def status(
     updates or security updates. Filtering for security updates
     implies filtering for updates as well.
 
-    Output can also be sorted by any column with --sort, optionally
-    reversed with --reverse. Sorting by 'version' groups hosts by
+    Output can also be sorted by any column with `--sort`, optionally
+    reversed with `--reverse`. Sorting by 'version' groups hosts by
     flavor first, since versions are not comparable across flavors.
 
     When sorting by any column other than name, hosts with unknown
     or unsupported values for that column will be grouped together at the
     end.
 
-    Use --full to include extra columns, such as the host description.
+    Use `--full` to include extra columns, such as the host description.
 
     No matches when filtering will exit with code 3.
 
@@ -336,11 +336,11 @@ def status(
     updates_only
         Show only hosts with pending updates
     security_only
-        Show only hosts with pending security updates (implies --updates-only)
+        Show only hosts with pending security updates (implies `--updates-only`)
     sort
         Sort the table by the given column
     reverse
-        Reverse the sort order (requires --sort)
+        Reverse the sort order (requires `--sort`)
     full
         Show additional columns, including host descriptions
     """

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -73,7 +73,7 @@ def generate(
     security_only
         Only report security updates
     tee
-        Also print report to stdout when using --output
+        Also print report to stdout when using `--output`
     quiet
         Suppress informational messages
     navigation

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -5,11 +5,12 @@ Reporting command module
 from pathlib import Path
 from typing import Annotated
 
-from cyclopts import App, Parameter, validators
+from cyclopts import App, ArgumentCollection, Group, Parameter, validators
 from rich.json import JSON
 
 from exosphere.commands.utils import (
     HostArg,
+    arg_requires_arg,
     console,
     err_console,
     get_hosts_or_all,
@@ -27,25 +28,63 @@ JSON for use in other tools or custom reporting.
 app = App(name="report", help=ROOT_HELP, help_flags=["--help"])
 
 
+def _validate_navigation_option(arguments: ArgumentCollection) -> None:
+    """
+    Group validator: ``--no-navigation`` only applies to HTML output.
+
+    The navigation section only exists in the HTML report, so disabling it
+    for any other format is meaningless.
+    """
+    by_field = {arg.field_info.name: arg for arg in arguments}
+    set_fields = {arg.field_info.name for arg in arguments.filter_by(value_set=True)}
+
+    no_navigation = "navigation" in set_fields and by_field["navigation"].value is False
+    if not no_navigation:
+        return
+
+    is_html = "format" in set_fields and by_field["format"].value == OutputFormat.html
+    if not is_html:
+        raise ValueError("--no-navigation only applies to --format html.")
+
+
+FILTER_GROUP = Group("Filtering Options", validator=validators.mutually_exclusive)
+OUTPUT_GROUP = Group(
+    "Output Options",
+    validator=(arg_requires_arg("tee", "output"), _validate_navigation_option),
+)
+
+
 @app.command
 def generate(
     *hosts: HostArg,
     format: Annotated[
-        OutputFormat, Parameter(name=["--format", "-f"])
+        OutputFormat, Parameter(name=["--format", "-f"], group=OUTPUT_GROUP)
     ] = OutputFormat.text,
     output: Annotated[
         Path | None,
-        Parameter(name=["--output", "-o"], validator=validators.Path(dir_okay=False)),
+        Parameter(
+            name=["--output", "-o"],
+            validator=validators.Path(dir_okay=False),
+            group=OUTPUT_GROUP,
+        ),
     ] = None,
     updates_only: Annotated[
-        bool, Parameter(name=["--updates-only", "-u"], negative="")
+        bool,
+        Parameter(name=["--updates-only", "-u"], negative="", group=FILTER_GROUP),
     ] = False,
     security_only: Annotated[
-        bool, Parameter(name=["--security-updates-only", "-s"], negative="")
+        bool,
+        Parameter(
+            name=["--security-updates-only", "-s"], negative="", group=FILTER_GROUP
+        ),
     ] = False,
-    tee: Annotated[bool, Parameter(name=["--tee"], negative="")] = False,
-    quiet: Annotated[bool, Parameter(name=["--quiet", "-q"], negative="")] = False,
-    navigation: bool = True,
+    tee: Annotated[
+        bool, Parameter(name=["--tee"], negative="", group=OUTPUT_GROUP)
+    ] = False,
+    quiet: Annotated[
+        bool, Parameter(name=["--quiet", "-q"], negative="", group=OUTPUT_GROUP)
+    ] = False,
+    navigation: Annotated[bool, Parameter(group=OUTPUT_GROUP)] = True,
 ) -> int:
     """
     Generate a report of the current inventory state.
@@ -57,6 +96,10 @@ def generate(
     The report can also be filtered to include only specific hosts by
     providing their names as arguments. If no hosts are specified,
     the report will include all hosts in the inventory.
+
+    It can further be narrowed to hosts with pending updates
+    (`--updates-only`) or pending security updates
+    (`--security-updates-only`), which are mutually exclusive.
 
     Note: Undiscovered or unsupported hosts are excluded from the report.
 
@@ -73,7 +116,7 @@ def generate(
     security_only
         Only report security updates
     tee
-        Also print report to stdout when using `--output`
+        Also print report to stdout (requires `--output`)
     quiet
         Suppress informational messages
     navigation

--- a/src/exosphere/commands/sudo.py
+++ b/src/exosphere/commands/sudo.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 import fabric
 import fabric.util
-from cyclopts import App, Parameter
+from cyclopts import App, Group, Parameter, validators
 from rich.table import Table
 
 from exosphere import app_config
@@ -283,13 +283,25 @@ def providers(name: str | None = None, /) -> int:
     return 0
 
 
+# Target group for sudo generate
+TARGET_GROUP = Group(
+    "Target",
+    help="(Required, Mutually Exclusive)",
+    validator=validators.mutually_exclusive,
+)
+
+
 @app.command
 def generate(
     *,
     host: Annotated[
-        Host | None, HOST_PARAMETER, Parameter(name=["--host", "-h"])
+        Host | None,
+        HOST_PARAMETER,
+        Parameter(name=["--host", "-h"], group=TARGET_GROUP),
     ] = None,
-    provider: Annotated[str | None, Parameter(name=["--provider", "-p"])] = None,
+    provider: Annotated[
+        str | None, Parameter(name=["--provider", "-p"], group=TARGET_GROUP)
+    ] = None,
     user: Annotated[str | None, Parameter(name=["--user", "-u"])] = None,
 ) -> int:
     """
@@ -316,10 +328,6 @@ def generate(
             "[red]You must specify either --host or --provider.[/red]\n"
             "Use --help for more information."
         )
-        return 1  # Input error
-
-    if host and provider:
-        err_console.print("[red]--host and --provider are mutually exclusive.[/red]")
         return 1  # Input error
 
     provider_infos = _get_provider_infos()

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -10,9 +10,10 @@ as well as display bits around task execution, errors and status.
 
 import platform
 import sys
+from collections.abc import Callable
 from typing import Annotated
 
-from cyclopts import Parameter
+from cyclopts import ArgumentCollection, Parameter
 from rich import box
 from rich.columns import Columns
 from rich.console import Console
@@ -59,6 +60,37 @@ HOST_PARAMETER = Parameter(n_tokens=1, converter=resolve_host, accepts_keys=Fals
 
 # Annotation for a positional Host argument that arrives already resolved.
 HostArg = Annotated[Host, HOST_PARAMETER]
+
+
+def arg_requires_arg(field: str, required: str) -> Callable[[ArgumentCollection], None]:
+    """
+    Build a group validator enforcing a one-way "requires" dependency.
+
+    If the ``field`` parameter is supplied with a truthy value, then
+    ``required`` must also be supplied; otherwise an input error is raised,
+    naming both options by their primary CLI flag.
+
+    Both parameters must belong to the same parameter group for the
+    validator to see them. The message is derived from the arguments::
+
+        Group("Sorting", validator=arg_requires_arg("reverse", "sort"))
+        # --reverse without --sort -> "--reverse requires --sort."
+
+    :param field: Parameter (field) name whose truthy value triggers the rule.
+    :param required: Parameter (field) name that must then also be present.
+    :return: A group validator callable suitable for a parameter group.
+    """
+
+    def _validator(arguments: ArgumentCollection) -> None:
+        by_field = {arg.field_info.name: arg for arg in arguments}
+        provided = {arg.field_info.name for arg in arguments.filter_by(value_set=True)}
+
+        if field in provided and by_field[field].value and required not in provided:
+            raise ValueError(
+                f"{by_field[field].names[0]} requires {by_field[required].names[0]}."
+            )
+
+    return _validator
 
 
 def get_version_string() -> str:
@@ -169,12 +201,12 @@ def get_hosts_or_all(
     """
     Obtain the given resolved hosts, or all inventory hosts if none were given.
 
-    Helper intented exclusively for commands that take a variadic
+    Helper intended exclusively for commands that take a variadic
     ``*names: HostArg`` argument, and hinges on unknown hosts being
     already rejected by the CLI Converter.
 
     Meant to handle the common "no hosts specified -> all hosts" default,
-    the empty inventory scenario, nd the optional supported only filter.
+    the empty inventory scenario, and the optional supported only filter.
 
     :param hosts: Resolved hosts from a variadic host argument (empty for all).
     :param supported_only: Return only supported hosts, with warning

--- a/src/exosphere/errors.py
+++ b/src/exosphere/errors.py
@@ -6,8 +6,10 @@ Exosphere application, along with presentation helpers that rewrite
 inscrutable upstream error messages into something a human can act on.
 """
 
-from cyclopts import CycloptsError, CycloptsPanel, UnusedCliTokensError
+from cyclopts import CycloptsError, UnusedCliTokensError
+from rich.box import ROUNDED
 from rich.console import RenderableType
+from rich.panel import Panel
 
 # Standard authentication error message for better UX
 # This is intended to be displayed whenever Paramiko raises
@@ -47,16 +49,27 @@ def error_formatter(error: CycloptsError) -> RenderableType:
     - Apply a consistent visual style to all errors, with the ability
       to change them in one central place, if necessary.
 
-    As long as what is returns is a Rich Renderable, all is well.
+    As long as what it returns is a Rich Renderable, all is well.
 
     :param error: The CycloptsError to handle
     :return: a Renderable with the error object
     """
+    message: RenderableType
+
     if isinstance(error, UnusedCliTokensError):
         tokens = ", ".join(error.unused_tokens or [])
-        return CycloptsPanel(f"Unexpected argument(s): {tokens}. See --help for usage.")
+        message = f"Unexpected argument(s): {tokens}. See --help for usage."
+    else:
+        message = error
 
-    return CycloptsPanel(error)
+    return Panel(
+        message,
+        title="Error",
+        title_align="left",
+        border_style="red",
+        box=ROUNDED,
+        expand=False,
+    )
 
 
 class DataRefreshError(Exception):

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -413,34 +413,20 @@ class TestStatusCommand:
         assert "host3" not in out
         assert "Host Status (security updates only)" in out
 
-    def test_both_filters_combined(self, create_host, mock_inventory, capsys):
+    def test_both_filters_mutually_exclusive(self, create_host, mock_inventory, capsys):
         """
-        Test status command with both --updates-only and --security-only flags.
-        Since --security-only takes precedence, it should behave exactly like --security-only alone.
+        --updates-only and --security-only are mutually exclusive; supplying
+        both is rejected as an input error by the Filtering Options validator.
         """
-        host_with_both = create_host(
-            name="host1", updates=[1, 2, 3], security_updates=[1]
-        )
-        host_updates_only = create_host(
-            name="host2", updates=[1, 2], security_updates=[]
-        )
-        host_no_updates = create_host(name="host3", updates=[], security_updates=[])
+        mock_inventory.hosts = [
+            create_host(name="host1", updates=[1, 2, 3], security_updates=[1])
+        ]
 
-        mock_inventory.hosts = [host_with_both, host_updates_only, host_no_updates]
+        with pytest.raises(SystemExit) as exc_info:
+            inventory_module.app(["status", "--updates-only", "--security-only"])
 
-        code = inventory_module.app(
-            ["status", "--updates-only", "--security-only"],
-            result_action="return_value",
-        )
-
-        out = capsys.readouterr().out
-        assert code == 0
-        assert "host1" in out
-        assert "host2" not in out
-        assert "host3" not in out
-        # Verify that security-only takes precedence in the title
-        assert "(security updates only)" in out
-        assert "(updates only)" not in out
+        assert exc_info.value.code == 1
+        assert "Mutually exclusive arguments" in capsys.readouterr().err
 
     def test_no_hosts_matching_criteria(self, create_host, mock_inventory, capsys):
         """
@@ -541,24 +527,20 @@ class TestStatusCommand:
 
         assert exc_info.value.code != 0
 
-    def test_reverse_without_sort_warns(self, create_host, mock_inventory, capsys):
+    def test_reverse_without_sort_errors(self, create_host, mock_inventory, capsys):
         """
-        Test --reverse without --sort is a no-op (warns, still succeeds).
+        Test --reverse without --sort is rejected by the validation
         """
         mock_inventory.hosts = [
             create_host(name="bravo"),
             create_host(name="alpha"),
         ]
 
-        code = inventory_module.app(
-            ["status", "--reverse"], result_action="return_value"
-        )
+        with pytest.raises(SystemExit) as exc_info:
+            inventory_module.app(["status", "--reverse"])
 
-        captured = capsys.readouterr()
-        assert code == 0
-        # Order should be unchanged (config order preserved)
-        assert captured.out.index("bravo") < captured.out.index("alpha")
-        assert "--reverse has no effect without --sort" in captured.err
+        assert exc_info.value.code == 1
+        assert "--reverse requires --sort" in capsys.readouterr().err
 
 
 class TestSaveCommand:

--- a/tests/commands/test_report.py
+++ b/tests/commands/test_report.py
@@ -445,3 +445,35 @@ class TestGenerateCommand:
             report.app(["generate", "--format", "json", "--output", str(tmp_path)])
 
         assert exc_info.value.code == 1  # Input error from validator
+
+    def test_tee_requires_output(self, mock_get_hosts, sample_host, capsys):
+        """--tee without --output is rejected by the validator"""
+        mock_get_hosts([sample_host])
+
+        with pytest.raises(SystemExit) as exc_info:
+            report.app(["generate", "--tee"])
+
+        assert exc_info.value.code == 1
+        assert "--tee requires --output" in capsys.readouterr().err
+
+    def test_no_navigation_requires_html(self, mock_get_hosts, sample_host, capsys):
+        """--no-navigation only applies to HTML output only"""
+        mock_get_hosts([sample_host])
+
+        with pytest.raises(SystemExit) as exc_info:
+            report.app(["generate", "--format", "text", "--no-navigation"])
+
+        assert exc_info.value.code == 1
+        assert (
+            "--no-navigation only applies to --format html" in capsys.readouterr().err
+        )
+
+    def test_filters_mutually_exclusive(self, mock_get_hosts, sample_host, capsys):
+        """--updates-only and --security-updates-only are mutually exclusive."""
+        mock_get_hosts([sample_host])
+
+        with pytest.raises(SystemExit) as exc_info:
+            report.app(["generate", "--updates-only", "--security-updates-only"])
+
+        assert exc_info.value.code == 1
+        assert "Mutually exclusive arguments" in capsys.readouterr().err

--- a/tests/commands/test_sudo.py
+++ b/tests/commands/test_sudo.py
@@ -338,18 +338,16 @@ class TestGenerateCommand:
     ):
         """
         Test the sudo generate command with both host and provider specified.
-        This should raise an error since only one can be specified at a time.
+        This should return a failure since they are mutually exclusive.
         """
         mock_inventory.get_host.return_value = dummy_host
         mock_inventory.hosts = [dummy_host]
 
-        code = sudo.app(
-            ["generate", "--host", "dummy_host", "--provider", "apt"],
-            result_action="return_value",
-        )
+        with pytest.raises(SystemExit) as exc_info:
+            sudo.app(["generate", "--host", "dummy_host", "--provider", "apt"])
 
-        assert code == 1  # Input error
-        assert "--host and --provider are mutually exclusive" in capsys.readouterr().err
+        assert exc_info.value.code == 1
+        assert "Mutually exclusive arguments" in capsys.readouterr().err
 
     def test_with_host(
         self, mock_inventory, dummy_host, mock_pkgmanager_factory, capsys

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -112,6 +112,60 @@ class TestResolveHost:
         assert exc_info.value.code == 2
 
 
+class TestRequires:
+    """Tests for the requires() group-validator factory."""
+
+    @staticmethod
+    def _app():
+        from typing import Annotated, Optional
+
+        from cyclopts import App, Group, Parameter
+
+        group = Group(
+            "Deps", validator=utils_module.arg_requires_arg("dependent", "required")
+        )
+        app = App(name="t")
+
+        @app.command
+        def run(
+            dependent: Annotated[
+                bool, Parameter(name=["--dependent"], negative="", group=group)
+            ] = False,
+            required: Annotated[
+                Optional[str], Parameter(name=["--required"], group=group)
+            ] = None,
+        ) -> int:
+            return 0
+
+        return app
+
+    def test_dependent_without_required_errors(self, capsys):
+        """The dependent flag without its requirement is an input error."""
+        with pytest.raises(SystemExit) as exc_info:
+            self._app()(["run", "--dependent"])
+
+        assert exc_info.value.code == 1
+        # Message is derived from the arguments' primary CLI names.
+        assert "--dependent requires --required" in capsys.readouterr().err
+
+    def test_dependent_with_required_ok(self):
+        """Both supplied is valid."""
+        code = self._app()(
+            ["run", "--dependent", "--required", "x"], result_action="return_value"
+        )
+        assert code == 0
+
+    def test_neither_ok(self):
+        """Neither supplied is valid (the rule only triggers on the dependent)."""
+        code = self._app()(["run"], result_action="return_value")
+        assert code == 0
+
+    def test_required_alone_ok(self):
+        """The required flag alone is valid."""
+        code = self._app()(["run", "--required", "x"], result_action="return_value")
+        assert code == 0
+
+
 class TestGetHostsOrAll:
     """Test the get_hosts_or_all helper."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import sys
 import types
 
 import pytest
+from cyclopts import Group
 
 from exosphere import __version__, cli
 from exosphere.config import Configuration
@@ -26,6 +27,16 @@ def test_subapps_share_root_help_formatter() -> None:
 
     for name in names:
         assert cli.app[name].help_formatter is root_formatter, name
+
+
+def test_root_help_version_grouped_as_parameters() -> None:
+    """The flags should not be in "Commands", like Typer"""
+    from exosphere import cli
+
+    for flag in ("--help", "--version"):
+        group = cli.app[flag].group
+        assert isinstance(group, tuple)
+        assert any(isinstance(g, Group) and g.name == "Parameters" for g in group), flag
 
 
 def test_repl_root(mocker, caplog, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,20 @@ def _console(patch_console):
     patch_console(cli)
 
 
+def test_subapps_share_root_help_formatter() -> None:
+    """Every group sub-app shares the root's help_formatter."""
+    from exosphere import cli
+
+    root_formatter = cli.app.help_formatter
+    assert root_formatter is not None
+
+    names = [name for name in cli.app if not name.startswith("-")]
+    assert names  # sanity: sub-apps are registered
+
+    for name in names:
+        assert cli.app[name].help_formatter is root_formatter, name
+
+
 def test_repl_root(mocker, caplog, capsys) -> None:
     """Interactive entrypoint prints the banner and starts the REPL."""
     from exosphere import cli

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev1"
+version = "3.0.0.dev2"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Adds multiple miscellaneous presentation and validation improvement to the CLI, namely:

* Help and Error formatting changes, to better reproduce previous Typer behavior
* Grouping of certain command arguments and options in logical groups, showing in help as a labeled block, to make them easier to understand and look up. This improves mainly complex commands like `sudo` and `report`, which have a bunch of context specific commands.
* Add group validators for parameter validation, offloading the mutually exclusive checks we do here and there to validate flags and options out of the command's body. Also normalizes error message display for these scenarios.
* In cases where one option had precedence over another (i.e. `--security-only` and `--updates-only`), the flags have just been made mutually exclusive instead, which is much clearer and carries less surprise for the user.

Docstrings have been cleaned up to properly display in the new CLI help system as well, and the tests suite has been expanded to cover the new functionality.