### PR TITLE
CLI: Skip unsupported hosts during sync and refresh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev2"
+version = "3.0.0.dev3"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -179,19 +179,25 @@ def refresh(
         )
         console.print() if verbose else None
 
+    # Unsupported hosts can't sync or refresh, partition them off
+    # This is handed to the task runner which will handle display
+    runnable = [host for host in hosts if host.supported]
+    skipped = [host for host in hosts if not host.supported]
+
     # If sync is requested, we will run the sync_repos task
     # Same as discovery, simple spinner
     if sync:
         console.print("[dim]Repository Sync:[/dim]") if verbose else None
         run_task_with_progress(
             inventory=inventory,
-            hosts=hosts,
+            hosts=runnable,
             operation=HostOperation.SYNC,
             task_description="Syncing package repositories",
             display_hosts=verbose,
             collect_errors=False,
             immediate_error_display=True,
             progress_args=SPINNER_PROGRESS_ARGS,
+            skipped=skipped,
         )
         console.print() if verbose else None
 
@@ -200,12 +206,13 @@ def refresh(
     console.print("[dim]Updates Refresh:[/dim]") if verbose else None
     errors = run_task_with_progress(
         inventory=inventory,
-        hosts=hosts,
+        hosts=runnable,
         operation=HostOperation.REFRESH,
         task_description="Refreshing package updates",
         display_hosts=verbose,
         collect_errors=True,
         immediate_error_display=False,
+        skipped=skipped,
     )
 
     errors_table = Table(

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -29,6 +29,7 @@ from exosphere.objects import Host, HostOperation
 STATUS_FORMATS = {
     "success": "[[bold green]OK[/bold green]]",
     "failure": "[[bold red]FAILED[/bold red]]",
+    "skipped": "[[dim]SKIPPED[/dim]]",
 }
 
 console = Console()
@@ -263,6 +264,7 @@ def run_task_with_progress(
     immediate_error_display: bool = False,
     transient: bool = True,
     progress_args: tuple = (),
+    skipped: list[Host] | None = None,
 ) -> list[tuple[str, Exception]]:
     """
     Run a task on selected hosts with progress display.
@@ -293,6 +295,8 @@ def run_task_with_progress(
     :param transient: Whether progress bar disappears after completion
     :param progress_args: List of renderables to compose the Progress
         layout
+    :param skipped: Hosts that were skipped, to display with the
+        skipped status, when display_host is True. Purely for display.
     :return: List of (hostname, exception objects) tuples for any failed
         hosts
     """
@@ -300,6 +304,19 @@ def run_task_with_progress(
 
     with Progress(transient=transient, *progress_args) as progress:
         task = progress.add_task(task_description, total=len(hosts))
+
+        # Surface skipped hosts up front, if any. It is easier to do
+        # this before starting so it doesn't get tangled with other
+        # messages and the behavior of immediate errors.
+        if display_hosts and skipped:
+            for host in skipped:
+                progress.console.print(
+                    Columns(
+                        [STATUS_FORMATS["skipped"], f"[bold]{host.name}[/bold]"],
+                        padding=(2, 1),
+                        equal=True,
+                    )
+                )
 
         for host, _, exc in inventory.run_task(operation, hosts=hosts):
             status_out = STATUS_FORMATS["failure"] if exc else STATUS_FORMATS["success"]

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -924,7 +924,30 @@ class TestRefreshCommand:
             display_hosts=False,
             collect_errors=True,
             immediate_error_display=False,
+            skipped=[],
         )
+
+    def test_refresh_skips_unsupported_hosts(self, mocker, mock_inventory, create_host):
+        """Refresh command skips unsupported hosts and informs"""
+        supported = create_host("supportedguy", supported=True)
+        unsupported = create_host("irixguy", supported=False)
+        mock_inventory.hosts = [supported, unsupported]
+
+        mock_run = mocker.patch.object(inventory_module, "run_task_with_progress")
+        mock_run.return_value = []
+
+        test_config = Configuration()
+        test_config.update_from_mapping({"options": {"cache_autosave": False}})
+        mocker.patch.object(inventory_module, "app_config", test_config)
+
+        code = inventory_module.app(["refresh", "--sync"], result_action="return_value")
+        assert code == 0
+
+        # Unsupported hosts should be sent to runner as skipped
+        assert mock_run.call_count == 2
+        for call in mock_run.call_args_list:
+            assert call.kwargs["hosts"] == [supported]
+            assert call.kwargs["skipped"] == [unsupported]
 
     def test_refresh_with_discover(self, mocker, mock_inventory, create_host):
         """Test refresh command with --discover option."""

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -368,6 +368,46 @@ class TestRunTaskWithProgress:
         mock_progress_instance.add_task.assert_called_once_with("Testing task", total=2)
         assert mock_progress_instance.update.call_count == 2
 
+    def test_run_task_displays_skipped_hosts(
+        self, mock_inventory, mock_console, mocker
+    ):
+        """Skipped hosts are displayed separately from total progress"""
+        host1 = mocker.Mock()
+        host1.name = "host1"
+        skipped_host = mocker.Mock()
+        skipped_host.name = "irixbox"
+
+        mock_inventory.run_task.return_value = [(host1, None, None)]
+
+        mock_progress = mocker.patch("exosphere.commands.utils.Progress")
+        mock_progress_instance = mock_progress.return_value.__enter__.return_value
+        mock_progress_instance.add_task.return_value = "task_id"
+
+        result = utils_module.run_task_with_progress(
+            inventory=mock_inventory,
+            hosts=[host1],
+            operation=HostOperation.REFRESH,
+            task_description="Refreshing",
+            display_hosts=True,
+            skipped=[skipped_host],
+        )
+
+        assert result == []
+        # Only the runnable host is dispatched; total excludes the skipped one.
+        mock_inventory.run_task.assert_called_once_with(
+            HostOperation.REFRESH, hosts=[host1]
+        )
+        mock_progress_instance.add_task.assert_called_once_with("Refreshing", total=1)
+
+        # The skipped host is rendered with a SKIPPED status.
+        rendered = [
+            str(renderable)
+            for call in mock_progress_instance.console.print.call_args_list
+            for renderable in getattr(call.args[0], "renderables", [])
+        ]
+        assert any("SKIPPED" in chunk for chunk in rendered)
+        assert any("irixbox" in chunk for chunk in rendered)
+
     def test_run_task_with_errors(self, mock_inventory, mock_console, mocker):
         """Test task execution with some errors."""
         console_mock, err_console_mock = mock_console

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev2"
+version = "3.0.0.dev3"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Previously, hosts would indiscriminately be handed over to the task
runner, which would return a somewhat misleading OK status due to the
absence of exception when trying to run sync or refresh on an
unsupported host.

This now pre-sorts the list of hosts and hands skipped hosts over to the
dispatch function, which will display them with a dim SKIPPED status tag
and not put them in the thread pool at all.

This leads to clearer output, better status report in verbose mode, and
fewer wasted executor threads spent on hosts that will do nothing.

Undiscovered hosts still attempt to run refresh and sync, and will fail,
which is expected and desirable, since discovering hosts is an
actionable state, and should be reported as such, whereas unsupported
is very much final in most cases.