### PR TITLE
REPL: Fix help behavior for invalid subcommands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev3"
+version = "3.0.0.dev4"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/main.py
+++ b/src/exosphere/main.py
@@ -228,7 +228,8 @@ def main() -> None:
 
     # Launch the regular CLI or REPL
     if len(sys.argv) > 1:
-        cli.app()
+        # Non-interactive errors should display help
+        cli.app(help_on_error=True)
     else:
         cli.start_interactive()
 

--- a/src/exosphere/repl.py
+++ b/src/exosphere/repl.py
@@ -391,8 +391,15 @@ class ExosphereREPL:
         # Route --help through scoped help handler
         # Rewrites command names to be relative
         if any(token in _HELP_FLAGS for token in args):
-            self._scoped_help(args)
-            return
+            if self._scoped_help(args):
+                return
+
+            # Fall back to normal dispatch if scoped help couldn't
+            # handle it (e.g. unrecognized command)
+            args = [token for token in args if token not in _HELP_FLAGS]
+            if not args:
+                return
+            head = args[0]
 
         # Bare groups (sub-app that has subcommands but has no further
         # tokens, and has no default command) also get routed to scoped
@@ -423,7 +430,7 @@ class ExosphereREPL:
             self.console.print(f"[red]Error executing {head}: {e}[/red]")
             logger.exception("Error executing command '%s'", head)
 
-    def _scoped_help(self, args: list[str]) -> None:
+    def _scoped_help(self, args: list[str]) -> bool:
         """
         Render help for the typed command, with relative command name
 
@@ -431,14 +438,27 @@ class ExosphereREPL:
         command for usage lines, which is much friendlier in context.
 
         Example: "exosphere sudo generate" --> "sudo generate"
+
+        Returns False when the tokens leave an unrecognized command, so the
+        caller can fall back to normal dispatch (surfacing the proper
+        unknown-command error rather than the root help).
         """
         tokens = [token for token in args if token not in _HELP_FLAGS]
-        _chain, apps, _unused = self.app.parse_commands(tokens)
+        chain, apps, unused = self.app.parse_commands(tokens)
+
+        # If there are leftover tokens that don't look like options or their
+        # values, don't try to twiddle help any further.
+        # NOTE: misfires for a group whose default command takes a positional
+        # (none do today, but noting for the future).
+        if _subcommands(apps[-1]) and unused and not unused[0].startswith("-"):
+            return False
 
         if len(apps) >= 2:
-            apps[1].help_print(list(_chain[1:]))
+            apps[1].help_print(list(chain[1:]))
         else:
             self.app.help_print([])
+
+        return True
 
     def _show_help(self, args: list[str]) -> None:
         """
@@ -458,9 +478,11 @@ class ExosphereREPL:
                 "Use 'help' without arguments for general help."
             )
         else:
-            # Specific command help, delegate to scoped help
-            # which in turns lets Cyclopts handle it entirely.
-            self._scoped_help([args[0], "--help"])
+            # Specific command help, delegate to scoped help. If the command
+            # isn't recognized, dispatch it normally so Cyclopts reports the
+            # unknown command (and suggestions) rather than rendering nothing.
+            if not self._scoped_help([args[0], "--help"]):
+                self._execute_command([args[0]])
 
     def _show_general_help(self) -> None:
         """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -87,7 +87,7 @@ class TestMain:
 
         mock_load_first_config.assert_called_once()
         mock_setup_logging.assert_called_once()
-        mock_cli_app.assert_called_once()
+        mock_cli_app.assert_called_once_with(help_on_error=True)
 
         assert "Configuration loaded from:" in caplog.text
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -419,6 +419,16 @@ class TestReplCommands:
         assert "show" in out
         assert "--updates" in out
 
+    def test_help_flag_with_command_options_shows_help(self, repl, capsys):
+        """Regression test: Don't parse option args as invalid commands"""
+        instance, recorder = repl
+
+        instance.execute_command("inventory status --sort os --help")
+        out = capsys.readouterr().out
+
+        assert "status" in out  # the command's help was rendered
+        assert recorder == []  # the command did not run
+
     def test_bare_group_shows_its_subcommands(self, repl, capsys):
         instance, _ = repl
 
@@ -456,15 +466,27 @@ class TestReplCommands:
         assert "show" in out  # it is the host group's help
         assert "exosphere" not in out  # root command is stripped
 
-    def test_help_for_unknown_command_falls_back_to_root(self, repl, capsys):
-        """Unknown commands show help for root command"""
+    def test_help_for_unknown_command_reports_it(self, repl, capsys):
+        """Help reports the unknown command, not root help."""
         instance, _ = repl
 
         instance.execute_command("help defenestrate")
-        out = capsys.readouterr().out
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
 
-        assert "host" in out
-        assert "inventory" in out
+        assert "Unknown command" in combined
+        assert "defenestrate" in combined
+
+    def test_help_flag_on_unknown_command_reports_it(self, repl, capsys):
+        """Help flags on unknown commands should also report the unknown command"""
+        instance, _ = repl
+
+        instance.execute_command("defenestrate --help")
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+
+        assert "Unknown command" in combined
+        assert "defenestrate" in combined
 
     def test_empty_line_is_noop(self, repl, capsys):
         """A blank line dispatches nothing and prints nothing."""

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev3"
+version = "3.0.0.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
This changes two things:

1. Running --help on an invalid command within the REPL no longer silently returns the help screen for the root command. Instead, it will now correctly display the intended "no such command" error.
2. When running through the CLI (not interactive), invalid commands will result in the help screen being shown before the error. While in interactive module, only the error will be shown.

I would note that the behavior of the parent command absorbing --help even on invalid subcommands is how Cyclopts behaves out of the box, so I am not going to "fix" it for CLI invocations. If that is a bug, it would need to be fixed upstream.