### PR TITLE
Tests: fix logger patching issues, pytest 9.1.0 compat

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -341,22 +342,21 @@ class TestMain:
         """
 
         basic_config = mocker.patch("logging.basicConfig")
-        get_logger = mocker.patch("logging.getLogger")
+        set_level = mocker.patch.object(logging.getLogger("exosphere"), "setLevel")
 
         from exosphere.main import setup_logging
 
         setup_logging("INFO")
 
         basic_config.assert_called()
-        get_logger.assert_any_call("exosphere")
-        get_logger.assert_any_call("exosphere.main")
+        set_level.assert_called_once_with("INFO")
 
     def test_setup_logging_file_handler(self, mocker, tmp_path):
         """
         Test setup_logging with a log_file (should use FileHandler).
         """
         basic_config = mocker.patch("logging.basicConfig")
-        get_logger = mocker.patch("logging.getLogger")
+        set_level = mocker.patch.object(logging.getLogger("exosphere"), "setLevel")
         log_file = tmp_path / "test.log"
 
         from exosphere.main import setup_logging
@@ -364,8 +364,7 @@ class TestMain:
         setup_logging("DEBUG", str(log_file))
 
         basic_config.assert_called()
-        get_logger.assert_any_call("exosphere")
-        get_logger.assert_any_call("exosphere.main")
+        set_level.assert_called_once_with("DEBUG")
 
     def test_setup_logging_invalid_log_level(self):
         """
@@ -397,7 +396,7 @@ class TestMain:
         It should normalize to uppercase.
         """
         mocker.patch("logging.basicConfig")
-        get_logger = mocker.patch("logging.getLogger")
+        set_level = mocker.patch.object(logging.getLogger("exosphere"), "setLevel")
 
         from exosphere.main import setup_logging
 
@@ -407,9 +406,7 @@ class TestMain:
             pytest.fail("setup_logging raised ValueError unexpectedly!")
 
         # Check if the log level was set to DEBUG
-        get_logger.assert_any_call("exosphere")
-        get_logger.assert_any_call("exosphere.main")
-        get_logger().setLevel.assert_called_with("DEBUG")
+        set_level.assert_called_once_with("DEBUG")
 
     def test_main_logging_setup_exception(
         self, mocker, mock_setup_logging_exception, capsys

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from textual.widgets import Footer, Header
 
@@ -30,8 +32,17 @@ class TestExosphereUi:
 
     @pytest.fixture
     def mock_logger(self, mocker):
-        """Mock the exosphere logger."""
-        return mocker.patch("logging.getLogger")
+        """Mock the exosphere logger.
+
+        Patches addHandler/removeHandler on the actual logger object
+        rather than the global logging.getLogger, as to not interfere
+        with pytests's own log-capture plugin, which also calls
+        logging.getLogger() and would leak into teardown otherwise.
+        """
+        logger = logging.getLogger("exosphere")
+        mocker.patch.object(logger, "addHandler")
+        mocker.patch.object(logger, "removeHandler")
+        return logger
 
     @pytest.fixture
     def app(self):
@@ -129,10 +140,6 @@ class TestExosphereUi:
         mock_handler_instance = mocker.Mock(spec=UILogHandler)
         mock_ui_log_handler.return_value = mock_handler_instance
 
-        # Mock the exosphere logger
-        mock_exosphere_logger = mocker.Mock()
-        mock_logger.return_value = mock_exosphere_logger
-
         # Call on_mount
         app.on_mount()
 
@@ -146,8 +153,7 @@ class TestExosphereUi:
         mock_handler_instance.setFormatter.assert_called_once_with(mock_formatter)
 
         # Verify the handler was added to the exosphere logger
-        mock_logger.assert_called_with("exosphere")
-        mock_exosphere_logger.addHandler.assert_called_once_with(mock_handler_instance)
+        mock_logger.addHandler.assert_called_once_with(mock_handler_instance)
 
         # Verify switch_mode was called with dashboard
         mock_switch_mode.assert_called_once_with("dashboard")
@@ -161,16 +167,11 @@ class TestExosphereUi:
         mock_handler = mocker.Mock(spec=UILogHandler)
         app.ui_log_handler = mock_handler
 
-        # Mock the exosphere logger
-        mock_exosphere_logger = mocker.Mock()
-        mock_logger.return_value = mock_exosphere_logger
-
         # Call on_unmount
         app.on_unmount()
 
         # Verify the handler was removed from the logger
-        mock_logger.assert_called_with("exosphere")
-        mock_exosphere_logger.removeHandler.assert_called_once_with(mock_handler)
+        mock_logger.removeHandler.assert_called_once_with(mock_handler)
 
         # Verify the handler was closed
         mock_handler.close.assert_called_once()
@@ -178,20 +179,16 @@ class TestExosphereUi:
         # Verify the handler was set to None
         assert app.ui_log_handler is None
 
-    def test_on_unmount_with_no_handler(self, app, mock_logger, mocker):
+    def test_on_unmount_with_no_handler(self, app, mock_logger):
         """Test that on_unmount handles case when ui_log_handler is None."""
         # Ensure handler is None
         app.ui_log_handler = None
-
-        # Mock the exosphere logger
-        mock_exosphere_logger = mocker.Mock()
-        mock_logger.return_value = mock_exosphere_logger
 
         # Call on_unmount (should not raise any exceptions)
         app.on_unmount()
 
         # Verify logger methods were not called since handler was None
-        mock_exosphere_logger.removeHandler.assert_not_called()
+        mock_logger.removeHandler.assert_not_called()
 
     def test_app_has_required_methods(self, app):
         """Test that the app has all required methods and they are callable."""
@@ -232,28 +229,24 @@ class TestExosphereUi:
         # Set up a mock handler
         mock_handler = mocker.Mock(spec=UILogHandler)
         app.ui_log_handler = mock_handler
-        mock_exosphere_logger = mocker.Mock()
-        mock_logger.return_value = mock_exosphere_logger
 
         # Call on_unmount
         app.on_unmount()
 
         # Verify cleanup was performed
-        mock_exosphere_logger.removeHandler.assert_called_once_with(mock_handler)
+        mock_logger.removeHandler.assert_called_once_with(mock_handler)
         mock_handler.close.assert_called_once()
         assert app.ui_log_handler is None
 
-    def test_handler_cleanup_when_none(self, app, mock_logger, mocker):
+    def test_handler_cleanup_when_none(self, app, mock_logger):
         """Test that on_unmount handles None handler gracefully."""
         app.ui_log_handler = None
-        mock_exosphere_logger = mocker.Mock()
-        mock_logger.return_value = mock_exosphere_logger
 
         # Should not raise any exceptions
         app.on_unmount()
 
         # Logger methods should not be called since handler is None
-        mock_exosphere_logger.removeHandler.assert_not_called()
+        mock_logger.removeHandler.assert_not_called()
 
     @pytest.fixture
     def mock_context(self, mocker):

--- a/uv.lock
+++ b/uv.lock
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1262,9 +1262,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
pytest 9.1.0 introduced a change somewhere that surfaced a real issue
with the logger fixture in ui tests: we were patching the global
logging.getLogger, which is also called by pytest's own log capture
plugins and facilities, and so, the mock could leak into teardown and
essentially break the entire test session.

This did not happen before because <9.1.0 had different code that
was accidentally more defensive, but our fixture was still very brittle
and would have broken at some point anyways.

This change refactors the logger fixture to patch the actual logger
object instead, which is nicer anyways, and moves code out of the test
functions and into the shared fixture, which does get a proper teardown
now, which is arguably how it should have been done from day 1.

Similarly, there's a few other spots where we patched the global logger
object, and we've also moved to patching spies on the actual application
logger. While these did not trigger issues they were the same pattern
which now feels risky and brittle, in hindsight, and so this is safer.

Returning a MagicMock in these scenarios only essentially hides the issue.