### PR TITLE
CLI: Add --install-completion support

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -169,6 +169,68 @@ I don't like the ascii art banner in interactive mode
 You can disable it entirely with the ``no_banner``
 :ref:`config option <no_banner_option>`.
 
+After upgrading to 3.0, my old shell completion misbehaves
+----------------------------------------------------------
+
+Exosphere can install tab-completion for **zsh**, **bash** and **fish** with:
+
+.. code-block:: console
+
+   exosphere --install-completion
+
+Versions prior to **3.0** generated completion differently (via Typer) and
+wrote the scripts to *different* locations. Re-running ``--install-completion``
+installs the new script alongside the old one rather than replacing it, so the
+stale files from the previous version are left behind.
+
+For all cases **except PowerShell**, the new completion takes precedence and
+the leftovers are harmless, but it is cleanest to remove them. If a stale script
+ever did take precedence, it would try to run ``exosphere`` at completion time and
+drop into the interactive REPL, appearing to hang your shell.
+
+To clean up the previous version's files:
+
+- **bash**: delete ``~/.bash_completions/exosphere.sh`` and remove its
+  ``source`` line from ``~/.bashrc``.
+- **zsh**: delete ``~/.zfunc/_exosphere`` (the new script is installed under
+  ``~/.zsh/completions``, or your oh-my-zsh completions directory).
+- **fish**: nothing to do — the new script overwrites the old one at the
+  same path.
+
+.. attention::
+
+   Typer also supported PowerShell completion, but Exosphere 3.0 does **not**.
+   This makes cleanup *required* on PowerShell rather than optional: with no
+   new completion to replace it, the stale Typer completer remains active and
+   *will* try to run ``exosphere`` at completion time, dropping into the REPL
+   and appearing to hang your shell.
+
+   Typer appended its completion directly into your PowerShell profile (rather
+   than a separate file). To remove it, open the profile:
+
+   .. code-block:: powershell
+
+      notepad $PROFILE
+
+   and delete the Exosphere completion block, which looks roughly like:
+
+   .. code-block:: powershell
+
+      Import-Module PSReadLine
+      Set-PSReadLineKeyHandler -Key Tab -Function MenuComplete
+      $scriptblock = {
+          param($wordToComplete, $commandAst, $cursorPosition)
+          $Env:_EXOSPHERE_COMPLETE = "complete_powershell"
+          # ... several lines referencing exosphere ...
+      }
+      Register-ArgumentCompleter -Native -CommandName exosphere -ScriptBlock $scriptblock
+
+   Remove the ``$scriptblock`` assignment and the matching
+   ``Register-ArgumentCompleter ... -CommandName exosphere`` line. You can
+   leave the generic ``Import-Module PSReadLine`` /
+   ``Set-PSReadLineKeyHandler`` lines if other tools rely on them. Restart
+   PowerShell afterwards.
+
 When managing Ubuntu systems, will this handle snaps?
 -----------------------------------------------------
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -59,6 +59,7 @@ subcommands
 sudo
 sudoers
 syspatch
+typer
 templating
 tcp
 toJSON
@@ -72,3 +73,4 @@ webserver
 webstart
 writeout
 zigbee
+zsh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev4"
+version = "3.0.0.dev5"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/cli.py
+++ b/src/exosphere/cli.py
@@ -84,10 +84,14 @@ for subapp in (
     app.command(subapp)
     subapp.help_formatter = HELP_FORMATTER
 
-# Force root --help and --version flags to be part of the parameters
-# group instead of the commands one - this preserves previous behavior
+# Register the shell completion installer.
+app.register_install_completion_command()
+
+# Force root --help, --version and --install-completion flags to be
+# part of the parameters group instead of the commands one
+# This preserves previous CLI behavior
 _root_flags_group = Group("Parameters")
-for flag in ("--help", "--version"):
+for flag in ("--help", "--version", "--install-completion"):
     app[flag].group = _root_flags_group
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev4"
+version = "3.0.0.dev5"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Opt-in and group the --install-completion shell option for exosphere, mirroring the option offered out of the box with typer.

Unfortunately, there are implementation differences between cyclopts and typer that make it impossible for the Typer completion scripts to continue working past 3.0.

"Reinstalling" the completion scripts on 3.0 will leave behind cruft, but the new scripts should take precedence and not ruin christmas.

One exception is PowerShell, which is simply not supported. The old block of script dropped in the PowerShell profile will still be there, and won't work, seemingly hanging the shell when tab is pressed on an option. There's unfortunately not a whole lot I can do about this, but I have added cleanup instructions to the FAQ, and will mirror this information in the release notes. Given the rich completion offered by the REPL, I can only hope the amount of Windows users that relied on that kind of completion is small, and that the cleanup instructions are clear enough.