### PR TITLE
Misc 3.0 cleanups and fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev5"
+version = "3.0.0.dev6"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -14,7 +14,9 @@ from exosphere.commands.utils import (
     console,
     err_console,
     get_hosts_or_all,
+    get_inventory,
 )
+from exosphere.inventory import FilterMode
 from exosphere.reporting import OutputFormat, ReportRenderer, ReportScope, ReportType
 
 ROOT_HELP = """
@@ -126,6 +128,8 @@ def generate(
     report_type = ReportType.full
     report_scope = ReportScope.complete
 
+    inventory = get_inventory()
+
     selected_hosts = get_hosts_or_all(hosts, supported_only=True)
     if selected_hosts is None:
         return 1  # Input error: no hosts to report on
@@ -140,7 +144,9 @@ def generate(
         report_scope = ReportScope.filtered
 
     if updates_only:
-        selected_hosts = [host for host in selected_hosts if host.updates]
+        selected_hosts = inventory.filter_hosts(
+            FilterMode.UPDATES_ONLY, hosts=selected_hosts
+        )
         if not selected_hosts and not quiet:
             err_console.print(
                 "No hosts with available updates found, nothing to report."
@@ -150,7 +156,9 @@ def generate(
         report_type = ReportType.updates_only
 
     if security_only:
-        selected_hosts = [host for host in selected_hosts if host.security_updates]
+        selected_hosts = inventory.filter_hosts(
+            FilterMode.SECURITY_ONLY, hosts=selected_hosts
+        )
         if not selected_hosts and not quiet:
             err_console.print(
                 "No hosts with security updates found, nothing to report."

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -46,8 +46,13 @@ def resolve_host(type_: type, tokens) -> Host:
     :param tokens: The Cyclopts tokens parsed for this argument.
     :return: The resolved Host instance.
     """
+    if context.inventory is None:
+        raise ValueError("Inventory is not initialized.")
+
     name = tokens[0].value
-    host = get_inventory().get_host(name)
+    # Do not rely on get_inventory() here, to avoid raising
+    # SystemExit in the middle of argument parsing.
+    host = context.inventory.get_host(name)
     if host is None:
         raise ValueError(f"Host '{name}' not found in inventory.")
 

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -419,18 +419,12 @@ class TestHostCommands:
     def test_commands_bail_with_uninitialized_inventory(
         self, mocker, command, args, capsys
     ):
-        """
-        Test that all commands bail out with an uninitialized inventory.
-
-        The host argument converter resolves through get_inventory(), so an
-        uninitialized inventory aborts during binding with an application
-        error (exit 2).
-        """
+        """Test that all commands bail out with an uninitialized inventory."""
         # Patch the inventory to simulate it being uninitialized
         mocker.patch("exosphere.context.inventory", None)
 
         with pytest.raises(SystemExit) as exc_info:
             host_module.app([command] + args)
 
-        assert exc_info.value.code == 2  # Application error
+        assert exc_info.value.code == 1  # Input error from converter
         assert "Inventory is not initialized" in capsys.readouterr().err

--- a/tests/commands/test_report.py
+++ b/tests/commands/test_report.py
@@ -7,6 +7,7 @@ import pytest
 from exosphere.commands import report
 from exosphere.commands import utils as utils_module
 from exosphere.data import Update
+from exosphere.inventory import Inventory
 from exosphere.objects import Host
 from exosphere.reporting import ReportScope, ReportType
 
@@ -15,6 +16,27 @@ from exosphere.reporting import ReportScope, ReportType
 def _console(patch_console):
     """Install deterministic consoles for the report command module."""
     patch_console(report)
+
+
+@pytest.fixture(autouse=True)
+def mock_inventory(mocker):
+    """
+    Patch context inventory for all tests.
+
+    report.generate resolves a live inventory via get_inventory() and
+    delegates update/security filtering to the real Inventory.filter_hosts,
+    so we mirror this here.
+    """
+    fake_inventory = mocker.create_autospec(Inventory, instance=True)
+    fake_inventory.hosts = []
+
+    real = Inventory
+    fake_inventory.filter_hosts.side_effect = lambda mode, hosts=None: (
+        real.filter_hosts(fake_inventory, mode, hosts)
+    )
+
+    mocker.patch.object(utils_module.context, "inventory", fake_inventory)
+    return fake_inventory
 
 
 @pytest.fixture

--- a/tests/commands/test_sudo.py
+++ b/tests/commands/test_sudo.py
@@ -650,19 +650,13 @@ class TestSudoCommands:
     def test_commands_bail_with_uninitialized_inventory(
         self, mocker, command, args, capsys
     ):
-        """
-        Test that sudo commands bail out with an uninitialized inventory.
-
-        Host resolution runs through get_inventory() in the converter, so an
-        uninitialized inventory aborts during binding with an application
-        error (exit 2).
-        """
+        """Test that sudo commands bail out with an uninitialized inventory."""
         # Patch the inventory to simulate it being uninitialized
         mocker.patch.object(utils_module.context, "inventory", None)
 
         with pytest.raises(SystemExit) as exc_info:
             sudo.app([command] + args)
 
-        assert exc_info.value.code == 2  # Application error
+        assert exc_info.value.code == 1  # Input error from converter
         captured = capsys.readouterr()
         assert "Inventory is not initialized" in captured.out + captured.err

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -103,13 +103,11 @@ class TestResolveHost:
             utils_module.resolve_host(Host, [_token("nonexistent")])
 
     def test_resolve_host_uninitialized_inventory(self, mock_context):
-        """An uninitialized inventory aborts via get_inventory (app error)."""
+        """An uninitialized inventory raises ValueError mid-parse."""
         mock_context.inventory = None
 
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(ValueError, match="not initialized"):
             utils_module.resolve_host(Host, [_token("test-host")])
-
-        assert exc_info.value.code == 2
 
 
 class TestRequires:

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev5"
+version = "3.0.0.dev6"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Minor 3.0 cleanups and fixes:

Delegate host filtering to the inventory module for single source of truth.

Fix the Host argument converter to raise appropriate errors without relying on `get_inventory()`, improving user experience in interactive contexts. 

Update the test suite to reflect these changes .