### PR TITLE
Add log caps to Application logs, REPL History

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -157,7 +157,10 @@ These options are applied globally, and affect how Exosphere behaves at runtime.
 - :option:`default_sudo_policy`
 - :option:`debug`
 - :option:`log_file`
+- :option:`log_max_bytes`
+- :option:`log_backup_count`
 - :option:`history_file`
+- :option:`history_max_entries`
 - :option:`cache_autosave`
 - :option:`cache_autopurge`
 - :option:`cache_file`
@@ -371,6 +374,94 @@ and examples of how to set them in the configuration file.
                     }
                 }
 
+.. _log_max_bytes_option:
+
+.. option:: log_max_bytes
+
+    The maximum size, in bytes, that the :option:`log_file` may reach before
+    it is rotated. When the log file grows past this size, it is rolled over
+    and a fresh file is started.
+
+    This only applies when logging to a file; it has no effect on console
+    logging. Set to ``0`` to disable rotation entirely and let the log grow
+    without bound.
+
+    **Default**: ``5242880`` (5 MiB)
+
+    **Example**:
+
+    .. tabs::
+
+        .. group-tab:: YAML
+
+            .. code-block:: yaml
+
+                options:
+                  log_max_bytes: 10485760  # 10 MiB
+
+        .. group-tab:: TOML
+
+            .. code-block:: toml
+
+                [options]
+                log_max_bytes = 10485760  # 10 MiB
+
+        .. group-tab:: JSON
+
+            .. code-block:: json
+
+                {
+                    "options": {
+                        "log_max_bytes": 10485760
+                    }
+                }
+
+.. _log_backup_count_option:
+
+.. option:: log_backup_count
+
+    The number of rotated log files to keep. When :option:`log_file` is
+    rotated, older files are named with a numeric suffix (e.g.
+    ``exosphere.log.1``), and any beyond this count are deleted.
+
+    With the defaults, the total disk used by logs is therefore essentially
+    ``log_max_bytes * (log_backup_count + 1)``.
+
+    This must be a positive integer of ``1`` or more, any lower value is
+    simply clamped to ``1``, and a warning is logged.
+
+    To disable rotation entirely, set :option:`log_max_bytes` to ``0`` instead.
+
+    **Default**: ``3``
+
+    **Example**:
+
+    .. tabs::
+
+        .. group-tab:: YAML
+
+            .. code-block:: yaml
+
+                options:
+                  log_backup_count: 5
+
+        .. group-tab:: TOML
+
+            .. code-block:: toml
+
+                [options]
+                log_backup_count = 5
+
+        .. group-tab:: JSON
+
+            .. code-block:: json
+
+                {
+                    "options": {
+                        "log_backup_count": 5
+                    }
+                }
+
 .. option:: history_file
 
     A filesystem path to a file where Exosphere will store the REPL history.
@@ -407,6 +498,46 @@ and examples of how to set them in the configuration file.
                 {
                     "options": {
                         "history_file": "/home/alice/.exosphere_history"
+                    }
+                }
+
+.. _history_max_entries_option:
+
+.. option:: history_max_entries
+
+    The maximum number of entries to retain in the :option:`history_file`.
+    The history file is trimmed to the most recent entries when the
+    interactive REPL starts, so it cannot grow without bound.
+
+    Set to ``0`` to disable trimming and keep unlimited history.
+
+    **Default**: ``1000``
+
+    **Example**:
+
+    .. tabs::
+
+        .. group-tab:: YAML
+
+            .. code-block:: yaml
+
+                options:
+                  history_max_entries: 5000
+
+        .. group-tab:: TOML
+
+            .. code-block:: toml
+
+                [options]
+                history_max_entries = 5000
+
+        .. group-tab:: JSON
+
+            .. code-block:: json
+
+                {
+                    "options": {
+                        "history_max_entries": 5000
                     }
                 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev7"
+version = "3.0.0.dev8"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/config.py
+++ b/src/exosphere/config.py
@@ -42,9 +42,12 @@ class Configuration(dict):
             "log_file": str(
                 fspaths.LOG_DIR / "exosphere.log"
             ),  # Default log file for the application
+            "log_max_bytes": 5 * 1024 * 1024,  # Rotate log file past this size (5 MiB)
+            "log_backup_count": 3,  # Number of rotated log files to keep
             "history_file": str(
                 fspaths.STATE_DIR / "repl_history"
             ),  # Default history file for the repl
+            "history_max_entries": 1000,  # Trim repl history to this many entries
             "cache_autosave": True,  # Automatically save cache to disk after changes
             "cache_autopurge": True,  # Automatically purge hosts removed from inventory
             "cache_file": str(

--- a/src/exosphere/main.py
+++ b/src/exosphere/main.py
@@ -18,6 +18,7 @@ import logging
 import os
 import sys
 import tomllib
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Callable
 
@@ -64,8 +65,23 @@ def setup_logging(log_level: str, log_file: str | None = None) -> None:
     # Normalize log level to UPPERCASE
     log_level = log_level.upper()
 
+    # Log message values in case of config clamping
+    clamp_warning: tuple[int, int] | None = None
+
     if log_file:
-        handler = logging.FileHandler(log_file, encoding="utf-8")
+        backup_count = app_config["options"]["log_backup_count"]
+        clamped_backup_count = max(1, backup_count)
+
+        # Set log values for deferred warning
+        if clamped_backup_count != backup_count:
+            clamp_warning = (clamped_backup_count, backup_count)
+
+        handler = RotatingFileHandler(
+            log_file,
+            encoding="utf-8",
+            maxBytes=app_config["options"]["log_max_bytes"],
+            backupCount=clamped_backup_count,
+        )
     else:
         handler = logging.StreamHandler()
         handler.setLevel(log_level)
@@ -77,6 +93,16 @@ def setup_logging(log_level: str, log_file: str | None = None) -> None:
     )
 
     logging.getLogger("exosphere").setLevel(log_level)
+
+    # We don't raise an exception here, and defer this until now
+    # because this function gets called during the "startup exceptions
+    # are FATAL" phase of initialization, so we just log a warning.
+    if clamp_warning is not None:
+        logging.getLogger(__name__).warning(
+            "log_backup_count must be at least 1! using %d instead of %r",
+            *clamp_warning,
+        )
+
     logging.getLogger(__name__).info("Logging initialized with level: %s", log_level)
 
 

--- a/src/exosphere/repl.py
+++ b/src/exosphere/repl.py
@@ -38,6 +38,59 @@ BUILTINS = {
 }
 
 
+def _trim_history_file(path: str, max_entries: int) -> None:
+    """
+    Trim the history file to the most recent entries
+
+    the FileHistory backend only ever appends so the file grows
+    unrestricted over time. This helper function rewrites it in place,
+    keeping the amount of last entries specified by max_entries.
+
+    The on-disk format stores every entry as a block of things:
+     - A # <timestamp> header line
+     - One or more +<content> lines for the entry content
+
+    A non-positive max_entries disable trimming, and we swallow any I/O
+    errors since failure to trim shouldn't block the REPL.
+
+    :param path: Path to the history file.
+    :param max_entries: Maximum number of entries to retain.
+    """
+    # Early bail if trimming is disabled
+    if max_entries <= 0:
+        return
+
+    try:
+        # Don't normalize newlines, FileHistory doesn't.
+        with open(path, "r", encoding="utf-8", errors="replace", newline="") as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        return
+    except OSError as e:
+        logger.warning("Could not read history file for trimming: %s", e)
+        return
+
+    # Group lines into entries, each beginning at a "# <timestamp>" header.
+    entries: list[list[str]] = []
+    for line in lines:
+        if line.startswith("#"):
+            entries.append([line])
+        elif entries:
+            entries[-1].append(line)
+        # Lines before the first header (if any) are dropped as junk.
+
+    if len(entries) <= max_entries:
+        return
+
+    kept = "".join(line for entry in entries[-max_entries:] for line in entry)
+    try:
+        # Again: preserve endings because FileHistory expects it
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(kept)
+    except OSError as e:
+        logger.warning("Could not rewrite trimmed history file: %s", e)
+
+
 def _accepts_host(argument) -> bool:
     """
     Check if argument resolves host names.
@@ -273,11 +326,17 @@ class ExosphereREPL:
         The history file will be dumped in the State directory for
         Exosphere, according to platform conventions.
 
+        Before opening, the file is trimmed to the most recent
+        ``history_max_entries`` entries so it cannot grow without bound.
+
         Falls back to in-memory history if the file cannot be opened.
         """
         try:
-            history_file = app_config["options"]["history_file"]
-            return FileHistory(str(history_file))
+            history_file = str(app_config["options"]["history_file"])
+            _trim_history_file(
+                history_file, app_config["options"]["history_max_entries"]
+            )
+            return FileHistory(history_file)
         except Exception as e:  # noqa: BLE001
             logger.warning("Could not setup persistent history: %s", e)
             logger.warning("REPL is falling back to in-memory history")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -353,11 +353,23 @@ class TestMain:
 
     def test_setup_logging_file_handler(self, mocker, tmp_path):
         """
-        Test setup_logging with a log_file (should use FileHandler).
+        Test setup_logging with a log_file
+        Should use a RotatingFileHandler configured from the
+        log_max_bytes / log_backup_count options from config.
         """
+        from logging.handlers import RotatingFileHandler
+
         basic_config = mocker.patch("logging.basicConfig")
         set_level = mocker.patch.object(logging.getLogger("exosphere"), "setLevel")
         log_file = tmp_path / "test.log"
+
+        from exosphere import Configuration
+
+        config = Configuration()
+        config.update_from_mapping(
+            {"options": {"log_max_bytes": 1234, "log_backup_count": 7}}
+        )
+        mocker.patch("exosphere.main.app_config", config)
 
         from exosphere.main import setup_logging
 
@@ -365,6 +377,47 @@ class TestMain:
 
         basic_config.assert_called()
         set_level.assert_called_once_with("DEBUG")
+
+        handler = basic_config.call_args.kwargs["handlers"][0]
+        assert isinstance(handler, RotatingFileHandler)
+        assert handler.maxBytes == 1234
+        assert handler.backupCount == 7
+        handler.close()
+
+    @pytest.mark.parametrize("backup_count", [0, -5])
+    def test_setup_logging_clamps_backup_count(
+        self, mocker, tmp_path, caplog, backup_count
+    ):
+        """
+        Invalid integer values for backup count are clamped to 1
+        """
+        from logging.handlers import RotatingFileHandler
+
+        basic_config = mocker.patch("logging.basicConfig")
+        mocker.patch.object(logging.getLogger("exosphere"), "setLevel")
+        log_file = tmp_path / "test.log"
+
+        from exosphere import Configuration
+
+        config = Configuration()
+        config.update_from_mapping(
+            {"options": {"log_max_bytes": 1234, "log_backup_count": backup_count}}
+        )
+        mocker.patch("exosphere.main.app_config", config)
+
+        caplog.set_level(logging.WARNING, logger="exosphere.main")
+
+        from exosphere.main import setup_logging
+
+        setup_logging("DEBUG", str(log_file))
+
+        handler = basic_config.call_args.kwargs["handlers"][0]
+        assert isinstance(handler, RotatingFileHandler)
+        assert handler.backupCount == 1
+        handler.close()
+
+        # Check that we log a warning
+        assert "log_backup_count must be at least 1" in caplog.text
 
     def test_setup_logging_invalid_log_level(self):
         """

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -160,11 +160,89 @@ class TestReplInit:
 
         mocker.patch(
             "exosphere.repl.app_config",
-            {"options": {"history_file": str(history_file)}},
+            {
+                "options": {
+                    "history_file": str(history_file),
+                    "history_max_entries": 1000,
+                }
+            },
         )
 
         instance = ExosphereREPL(root)
 
+        assert isinstance(instance.history, FileHistory)
+
+    def test_history_trimmed_to_max_entries(self, fake_exosphere, mocker, tmp_path):
+        """Constructing the REPL should trim the history file to max_entries."""
+        root, _ = fake_exosphere
+        history_file = tmp_path / "history.txt"
+
+        # Seed a history file with 10 entries, oldest first.
+        seed = FileHistory(str(history_file))
+        for i in range(10):
+            seed.append_string(f"command {i}")
+
+        mocker.patch(
+            "exosphere.repl.app_config",
+            {"options": {"history_file": str(history_file), "history_max_entries": 3}},
+        )
+
+        ExosphereREPL(root)
+
+        # load_history_strings yields most-recent-first.
+        remaining = list(FileHistory(str(history_file)).load_history_strings())
+        assert remaining == ["command 9", "command 8", "command 7"]
+
+    def test_history_not_trimmed_under_limit(self, fake_exosphere, mocker, tmp_path):
+        """A history file under the limit should be left untouched."""
+        root, _ = fake_exosphere
+        history_file = tmp_path / "history.txt"
+
+        seed = FileHistory(str(history_file))
+        for i in range(3):
+            seed.append_string(f"command {i}")
+        original = history_file.read_text(encoding="utf-8")
+
+        mocker.patch(
+            "exosphere.repl.app_config",
+            {"options": {"history_file": str(history_file), "history_max_entries": 10}},
+        )
+
+        ExosphereREPL(root)
+
+        assert history_file.read_text(encoding="utf-8") == original
+
+    def test_history_trim_disabled_with_zero(self, fake_exosphere, mocker, tmp_path):
+        """A max_entries of 0 disables trimming entirely."""
+        root, _ = fake_exosphere
+        history_file = tmp_path / "history.txt"
+
+        seed = FileHistory(str(history_file))
+        for i in range(10):
+            seed.append_string(f"command {i}")
+        original = history_file.read_text(encoding="utf-8")
+
+        mocker.patch(
+            "exosphere.repl.app_config",
+            {"options": {"history_file": str(history_file), "history_max_entries": 0}},
+        )
+
+        ExosphereREPL(root)
+
+        assert history_file.read_text(encoding="utf-8") == original
+
+    def test_history_trim_missing_file_is_safe(self, fake_exosphere, mocker, tmp_path):
+        """Trimming a non-existent history file should not raise."""
+        root, _ = fake_exosphere
+        history_file = tmp_path / "does_not_exist.txt"
+
+        mocker.patch(
+            "exosphere.repl.app_config",
+            {"options": {"history_file": str(history_file), "history_max_entries": 5}},
+        )
+
+        # Should construct cleanly and fall through to a FileHistory.
+        instance = ExosphereREPL(root)
         assert isinstance(instance.history, FileHistory)
 
     def test_history_falls_back_to_memory(self, fake_exosphere, mocker, caplog):
@@ -173,7 +251,7 @@ class TestReplInit:
         # Ensure history file is configured
         mocker.patch(
             "exosphere.repl.app_config",
-            {"options": {"history_file": "/some/path"}},
+            {"options": {"history_file": "/some/path", "history_max_entries": 1000}},
         )
 
         # Oh no! FileHistory died somehow!

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev7"
+version = "3.0.0.dev8"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Changes the application logfile handler to use a rotating file handler instead, with configurable values for max file size and number of backup files.

The REPL history file is now capped by default at 1000 entries, with a custom handler that will trim the oldest entries, which was necessary since the format is made of Entries, which are blocks of delimited text.

These values can be configured in the config file, and have sane defaults.

The documentation has been update to reflect these changes, and tests have been added to verify the new functionality.

Resolves #32