### PR TITLE
UI: Select Sort Modal entries via quick key

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -34,6 +34,7 @@ keybinds
 kwargs
 linux
 lstrip
+MiB
 misconfiguration
 nopasswd
 nullable

--- a/docs/source/ui.rst
+++ b/docs/source/ui.rst
@@ -220,6 +220,10 @@ with the available filters.
 .. image:: /_static/filter_sample.png
    :alt: Example of Exosphere TUI Filter Prompt
 
+.. tip::
+   Each entry also has an underlined quick-select key (``u`` for "Updates Only",
+   for instance) that will **immediately** apply that filter when pressed.
+
 After selecting a filter, only hosts matching the criteria will be displayed.
 The active filter will be shown in the status bar at the bottom of the screen:
 
@@ -237,12 +241,14 @@ columns with the Arrow Keys, toggle reverse by pressing ``r`` (or focusing
 the checkbox with ``Tab`` and pressing ``Space``), and press ``Enter`` to
 apply.
 
-Each entry also has an underlined quick-select key (``H`` for
-*Host*, ``O`` for *OS*, ``S`` for *Security*, etc.) that applies that sort
-**immediately** when pressed.
-
 .. image:: /_static/sort_sample.png
    :alt: Example of Exosphere TUI Sort Prompt
+
+.. tip::
+   Each entry also has an underlined quick-select key (``h`` for
+   *Host*, ``o`` for *OS*, ``s`` for *Security*, etc.) that will select the
+   option when pressed. So to get a reverse sort by Security Updates, it is
+   possible to simply press ``ctrl+s, s, r, enter``.
 
 After applying a sort, the active sort field and direction are shown in
 the status bar alongside any active filter. You can restore the original

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev8"
+version = "3.0.0.dev9"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -195,10 +195,17 @@ class SortScreen(Screen):
         self.dismiss((field, reverse))
         event.stop()
 
-    def _apply_sort(self, field: SortField | None, event: Key) -> None:
-        """Read the reverse checkbox and dismiss with the chosen sort."""
-        reverse = self.query_one("#sort-reverse", Checkbox).value
-        self.dismiss((field, reverse))
+    def _select_field(self, field: SortField | None, event: Key) -> None:
+        """Select the enum's corresponding item in the list view"""
+        item_id = "sort-none" if field is None else f"sort-{field.value}"
+        sort_list = self.query_one("#sort-list", ListView)
+
+        for index, item in enumerate(sort_list.children):
+            if item.id == item_id:
+                sort_list.focus()
+                sort_list.index = index
+                break
+
         event.stop()
 
     def on_key(self, event: Key) -> None:
@@ -215,21 +222,21 @@ class SortScreen(Screen):
                 event.stop()
             case "d":
                 # Default Sort (config order)
-                self._apply_sort(None, event)
+                self._select_field(None, event)
             case "h":
-                self._apply_sort(SortField.HOST, event)
+                self._select_field(SortField.HOST, event)
             case "o":
-                self._apply_sort(SortField.OS, event)
+                self._select_field(SortField.OS, event)
             case "f":
-                self._apply_sort(SortField.FLAVOR, event)
+                self._select_field(SortField.FLAVOR, event)
             case "v":
-                self._apply_sort(SortField.VERSION, event)
+                self._select_field(SortField.VERSION, event)
             case "u":
-                self._apply_sort(SortField.UPDATES, event)
+                self._select_field(SortField.UPDATES, event)
             case "s":
-                self._apply_sort(SortField.SECURITY, event)
+                self._select_field(SortField.SECURITY, event)
             case "a":
-                self._apply_sort(SortField.STATUS, event)
+                self._select_field(SortField.STATUS, event)
 
 
 class HostDetailsPanel(Screen):

--- a/tests/ui/test_inventory_ui.py
+++ b/tests/ui/test_inventory_ui.py
@@ -666,35 +666,31 @@ class TestSortScreen:
             "default",
         ],
     )
-    def test_quick_key_dismisses_with_field(self, mocker, key, expected_field):
-        """Each quick-key applies its mapped field (default, non-reversed)."""
+    def test_quick_key_selects_field_without_dismissing(
+        self, mocker, key, expected_field
+    ):
+        """Each quick-key selects its field and does not dismiss."""
         screen = SortScreen()
-        mock_checkbox = mocker.Mock()
-        mock_checkbox.value = False
-        mocker.patch.object(screen, "query_one", return_value=mock_checkbox)
+
+        # List will have Default + sortfields, with ids "sort-none" and "sort-{field}"
+        item_ids = ["sort-none"] + [f"sort-{field.value}" for field in SortField]
+        expected_id = (
+            "sort-none" if expected_field is None else f"sort-{expected_field.value}"
+        )
+
+        mock_list = mocker.Mock()
+        mock_list.children = [mocker.Mock(id=item_id) for item_id in item_ids]
+        mocker.patch.object(screen, "query_one", return_value=mock_list)
         mock_dismiss = mocker.patch.object(screen, "dismiss")
 
         event = mocker.Mock()
         event.key = key
         screen.on_key(event)
 
-        mock_dismiss.assert_called_once_with((expected_field, False))
+        assert mock_list.index == item_ids.index(expected_id)
+        mock_list.focus.assert_called_once()
+        mock_dismiss.assert_not_called()  # We shouldn't dismiss here
         event.stop.assert_called_once()
-
-    @pytest.mark.parametrize("reverse", [True, False])
-    def test_quick_key_carries_reverse_state(self, mocker, reverse):
-        """Dismissing via quick key includes reverse checkbox state"""
-        screen = SortScreen()
-        mock_checkbox = mocker.Mock()
-        mock_checkbox.value = reverse
-        mocker.patch.object(screen, "query_one", return_value=mock_checkbox)
-        mock_dismiss = mocker.patch.object(screen, "dismiss")
-
-        event = mocker.Mock()
-        event.key = "h"
-        screen.on_key(event)
-
-        mock_dismiss.assert_called_once_with((SortField.HOST, reverse))
 
     def test_reverse_key_toggles_checkbox_without_dismissing(self, mocker):
         """'r' flips the reverse checkbox and does not dismiss."""

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev8"
+version = "3.0.0.dev9"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
After some dogfooding, dismissing immediately via the quick key felt jarring, since it's absolutely not intuitive to press 'r' first to select "Reverse", and then press the hotkey for the field you want to sort by *after*.

The quick keys now simply select the entry, and you are free to press "r" (or not) and then hit "enter" to apply the sort.

Documentation has been cleaned up to reflect this new behavior, and the hotkeys have been reframed as "tip" boxes instead of lost in the description of the feature.