### PR TITLE
Add file locking to prevent concurrent cache use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev9"
+version = "3.0.0.dev10"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [
@@ -35,6 +35,7 @@ dependencies = [
     "packaging>=24.0",
     "rich>=14.1.0",
     "cyclopts>=4.16.1",
+    "filelock>=3.29.4",
 ]
 
 [dependency-groups]

--- a/src/exosphere/context.py
+++ b/src/exosphere/context.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from filelock import FileLock
+
     from exosphere.inventory import Inventory
     from exosphere.pipelining import ConnectionReaper
 
 inventory: Inventory | None = None
 reaper: ConnectionReaper | None = None
 confpath: str | None = None
+cache_lock: FileLock | None = None

--- a/src/exosphere/main.py
+++ b/src/exosphere/main.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Callable
 
 import yaml
+from filelock import FileLock, Timeout
 from rich.traceback import install as install_rich_traceback
 
 from exosphere import app_config, cli, context, fspaths
@@ -208,12 +209,37 @@ def cleanup_connections() -> None:
         context.inventory.close_all(clear=True)
 
 
+@atexit.register
+def release_cache_lock() -> None:
+    """
+    Exit handler to release the cache file lock.
+
+    Registered via atexit to ensure the exclusive cache lock is released
+    on program exit. The OS frees the lock on process death regardless,
+    but releasing explicitly is cleaner and removes the sidecar lock
+    file swiftly.
+
+    Safe to call when no lock was ever acquired.
+    """
+    logger.debug("Running exit handler for cache lock release")
+
+    if context.cache_lock is not None and context.cache_lock.is_locked:
+        logger.debug("Releasing cache lock on exit")
+        context.cache_lock.release()
+
+
 def main() -> None:
     """
     Program Entry Point
     """
     # Install rich traceback handler early
     install_rich_traceback(console=err_console, show_locals=False)
+
+    # Fast-path calls to --version/-V to avoid unnecessary
+    # initialization and potential lock contention
+    if {"--version", "-V"} & set(sys.argv[1:]):
+        cli.app()
+        return
 
     # Ensure all required directories exist
     try:
@@ -243,6 +269,23 @@ def main() -> None:
             setup_logging(app_config["options"]["log_level"], log_file)
     except Exception as e:
         print(f"FATAL: Startup Error setting up logging: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Acquire exclusive lock on the cache file before inventory init.
+    # Prevents concurrent instances from sharing the same cache file.
+    # The lock is put on a sidecar .lock file, to avoid locking the
+    # cache file itself.
+    cache_file = app_config["options"]["cache_file"]
+    context.cache_lock = FileLock(f"{cache_file}.lock")
+
+    try:
+        context.cache_lock.acquire(blocking=False)
+    except Timeout:
+        err_console.print(
+            f"[red]FATAL:[/red] Another Exosphere instance is using this cache:\n"
+            f"  {cache_file}\n"
+            "Ensure no other instances with this configuration are running."
+        )
         sys.exit(1)
 
     # Initialize the inventory

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,6 +70,15 @@ class TestMain:
         mock_cls = mocker.patch("exosphere.main.Inventory")
         return mock_cls.return_value
 
+    @pytest.fixture(autouse=True)
+    def mock_filelock(self, mocker):
+        """
+        Autouse fixture to mock the cache FileLock.
+
+        Creating actual lock sidecars everywhere would be horrifying
+        """
+        return mocker.patch("exosphere.main.FileLock")
+
     def test_main(self, mocker, caplog):
         """
         Test the main function of the Exosphere application.
@@ -202,6 +211,65 @@ class TestMain:
 
         with pytest.raises(SystemExit):
             main()
+
+    def test_main_acquires_cache_lock(self, mocker, mock_filelock):
+        """
+        Test that main acquires an exclusive cache lock on the sidecar file.
+        """
+        from exosphere import app_config
+
+        mocker.patch("exosphere.main.load_first_config", return_value=True)
+        mocker.patch("exosphere.main.setup_logging")
+        mocker.patch("exosphere.cli.app")
+
+        from exosphere.main import main
+
+        main()
+
+        cache_file = app_config["options"]["cache_file"]
+        mock_filelock.assert_called_once_with(f"{cache_file}.lock")
+        mock_filelock.return_value.acquire.assert_called_once_with(blocking=False)
+
+    def test_main_cache_lock_contention(self, mocker, mock_filelock):
+        """
+        Test that main exits without building the inventory when the cache
+        lock is already held by another instance.
+        """
+        from filelock import Timeout
+
+        mocker.patch("exosphere.main.load_first_config", return_value=True)
+        mocker.patch("exosphere.main.setup_logging")
+        mocker.patch("exosphere.cli.app")
+
+        mock_inv_cls = mocker.patch("exosphere.main.Inventory")
+        mock_filelock.return_value.acquire.side_effect = Timeout("cache.lock")
+
+        from exosphere.main import main
+
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+        assert excinfo.value.code == 1
+        mock_inv_cls.assert_not_called()
+
+    def test_main_version_fast_path(self, mocker, monkeypatch, mock_filelock):
+        """
+        Test that --version flag skips init
+        """
+        monkeypatch.setattr("sys.argv", ["exosphere", "--version"])
+
+        mock_cli_app = mocker.patch("exosphere.cli.app")
+        mock_inv_cls = mocker.patch("exosphere.main.Inventory")
+        mock_load_first_config = mocker.patch("exosphere.main.load_first_config")
+
+        from exosphere.main import main
+
+        main()
+
+        mock_cli_app.assert_called_once_with()
+        mock_filelock.assert_not_called()  # No locks
+        mock_inv_cls.assert_not_called()  # No inventory init
+        mock_load_first_config.assert_not_called()  # No config load
 
     def test_load_first_config(self, mocker, mock_config):
         """
@@ -555,3 +623,37 @@ class TestMain:
             mock_inventory.close_all.assert_called_once_with(clear=True)
         else:
             mock_inventory.close_all.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "lock_present,is_locked,expected_release",
+        [
+            (True, True, True),
+            (True, False, False),
+            (False, False, False),
+        ],
+        ids=["held", "not_held", "no_lock"],
+    )
+    def test_release_cache_lock(
+        self, mocker, lock_present, is_locked, expected_release
+    ):
+        """
+        Test the release_cache_lock atexit handler across lock states.
+        """
+        from exosphere import context
+        from exosphere.main import release_cache_lock
+
+        mock_lock = None
+        if lock_present:
+            mock_lock = mocker.MagicMock()
+            mock_lock.is_locked = is_locked
+            context.cache_lock = mock_lock
+        else:
+            context.cache_lock = None
+
+        release_cache_lock()
+
+        if expected_release:
+            assert mock_lock is not None
+            mock_lock.release.assert_called_once()
+        elif mock_lock is not None:
+            mock_lock.release.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -529,11 +529,12 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev9"
+version = "3.0.0.dev10"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },
     { name = "fabric" },
+    { name = "filelock" },
     { name = "jinja2" },
     { name = "packaging" },
     { name = "platformdirs" },
@@ -573,6 +574,7 @@ dev = [
 requires-dist = [
     { name = "cyclopts", specifier = ">=4.16.1" },
     { name = "fabric", specifier = ">=3.2.2" },
+    { name = "filelock", specifier = ">=3.29.4" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "platformdirs", specifier = ">=4.3.8" },
@@ -623,6 +625,15 @@ wheels = [
 [package.optional-dependencies]
 pytest = [
     { name = "pytest" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Sets a nice, cross-platform lock around the specific cache file set in configuration to prevent multiple instances of Exosphere from running concurrently when they would share it.

The lock is implemented as a side-car .lock file, to avoid locking the cache itself. It is acquired early in the startup process, before inventory initialization, and released via atexit handlers on shutdown.

If the process dies, the lock will be released by the OS. The sidecar will be left behind in general, which is fine.

The lock is non-blocking and fails fast with a clear error message if encountered. There are no real risks of deadlocking here.

This implementation DOES allow for a second exosphere process to be run concurrently, if it uses a different configuration file with a different cache file path. This is intentional, as that would not be problematic.

Additionally, the --version flag has been fast-pathed to skip init and lock acquisition entirely, so running 'exosphere --version' will not be blocked by a lock held by another instance, since that would be particularly silly. The full 'version' command however, is not (mainly because it hinges on the configuration being initialized).

Resolves #230