### PR TITLE
Fix typos and grammatical errors, add gate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Unix-like hosts over SSH.
 ![exosphere demo](./demo.gif)
 
 It is targeted at small to medium sized networks, and is designed to be simple
-to deploy and use, requiring no central server, agents and complex dependencies
+to deploy and use, requiring no central server, agents, or complex dependencies
 on remote hosts.
 
-If you have SSH access to the hosts and your keypairs are loaded in a SSH Agent,
+If you have SSH access to the hosts and your keypairs are loaded in an SSH Agent,
 you are good to go!
 
 Simply follow the [Quickstart Guide](https://exosphere.readthedocs.io/en/stable/quickstart.html),
@@ -34,13 +34,13 @@ or see [the documentation](https://exosphere.readthedocs.io/en/stable/) to get s
   solutions
 - Does not require Python (or anything else) to be installed on remote systems
 - Parallel operations across hosts with optional SSH pipelining
-- Document based reporting in HTML, text or markdown format
+- Document-based reporting in HTML, text or markdown format
 - JSON output for integration with other tools
 
 ## Compatibility
 
 Exosphere itself is written in Python and is compatible with Python 3.13 or later.
-It can run nearly anywhere where Python is available, including Linux, MacOS,
+It can run nearly anywhere where Python is available, including Linux, macOS,
 and Windows (natively).
 
 Supported platforms for remote hosts include:

--- a/docs/source/_ext/exosphere_help.py
+++ b/docs/source/_ext/exosphere_help.py
@@ -1,5 +1,5 @@
 """
-Sphinx extension to render a SVG screenshot of Exosphere CLI help output
+Sphinx extension to render an SVG screenshot of Exosphere CLI help output
 
 Provides a Sphinx directive that renders the Cyclopts --help screen as
 an inline SVG, as a magic, dynamic, regenerates-on-build "screenshot".
@@ -9,7 +9,7 @@ of Sphinx extensions within Exosphere, but it does restore the help
 preview functionality that sphinxcontrib-typer provided previously.
 
 It mainly works through Rich's Console being able to output SVG with
-themeing and window chrome, which we then embed in the page. It uses
+theming and window chrome, which we then embed in the page. It uses
 a StringIO capture, remaining cross-platform and in-memory.
 
 The previous Typer-centric extension had a bit more options to

--- a/docs/source/api/providers_api.rst
+++ b/docs/source/api/providers_api.rst
@@ -11,7 +11,7 @@ and returning Update objects that can be used to populate state.
 
 Implementing a new provider requires creating a new class under
 ``exosphere.providers`` that inherits from the base provider class
-``exosphere.providers.api.Provider``.
+``exosphere.providers.api.PkgManager``.
 
 This class should implement the methods and members below.
 

--- a/docs/source/cachefile.rst
+++ b/docs/source/cachefile.rst
@@ -27,10 +27,10 @@ If it does not, this is a bug and should be reported.
 
 Clearing the Cache
 ------------------
-If you encounter issues or inconsistencies with cache, you can clear it.
+If you encounter issues or inconsistencies with the cache, you can clear it.
 It can generally safely just be deleted on disk, and will be recreated on next run.
 
-The cache file can also be manually cleared within exosphere in the :doc:`cli`:
+The cache file can also be manually cleared within Exosphere in the :doc:`cli`:
 
 .. code-block:: bash
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -175,7 +175,7 @@ Or, in short form:
    exosphere> inventory status -u -o security -r
 
 It will show hosts with updates, sorted by amount of security updates,
-descending, which is a great at a glance view of what to patch first.
+descending, which is a great at-a-glance view of what to patch first.
 
 .. admonition:: Note
 
@@ -359,7 +359,8 @@ errors and specific conditions.
 For instance, ``exosphere version check`` will return 3 if updates are available,
 and the various ``--updates-only`` filters on ``inventory status`` will also
 return 3 if no hosts matched what you requested, and lastly, ``sudo generate``
-will return it as well if no sudoers snippets need generated for that host/provider.
+will return it as well if no sudoers snippet needs to be generated for that
+host/provider.
 
 Commands returning 3 will typically inform you of the meaning in their
 help text.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -17,7 +17,7 @@ For instance, for a **YAML** configuration file, the default locations are:
 
         ``~/.config/exosphere/config.yaml``
 
-    .. group-tab:: MacOS
+    .. group-tab:: macOS
 
         ``~/Library/Application Support/exosphere/config.yaml``
 
@@ -74,7 +74,7 @@ file you wish to use.
 
 .. tabs::
 
-    .. group-tab:: Unix/MacOS
+    .. group-tab:: Unix/macOS
 
         .. code-block:: shell
 
@@ -110,7 +110,7 @@ environment variable:
 
 .. tabs::
 
-    .. group-tab:: Unix/MacOS
+    .. group-tab:: Unix/macOS
 
         .. code-block:: shell
 
@@ -246,7 +246,7 @@ and examples of how to set them in the configuration file.
 
     .. admonition:: Note
 
-        Depending your used Providers, you may not need to configure this at all!
+        Depending on the Providers you use, you may not need to configure this at all!
         See the :doc:`providers` documentation for more details.
 
         This is the global value that, by default, applies to all hosts.
@@ -469,7 +469,7 @@ and examples of how to set them in the configuration file.
     file ``repl_history``.
 
     This file is used to persist the command history across executions of Exosphere,
-    allowing you navigate through or search for previously executed commands.
+    allowing you to navigate through or search for previously executed commands.
 
     **Default**: (Platform Default)
 
@@ -693,10 +693,10 @@ and examples of how to set them in the configuration file.
 
 .. option:: stale_threshold
 
-    The number of seconds after which a host data is considered stale.
+    The number of seconds after which a host's data is considered stale.
 
     If a host has not been refreshed in this many seconds, an asterisk or
-    similar flag will be shown in the UIs to indicated that the update count
+    similar flag will be shown in the UIs to indicate that the update count
     may not be accurate, and that the host should be refreshed.
 
     The default is 24 hours, which is reasonable, but you may want a shorter
@@ -1095,7 +1095,7 @@ and examples of how to set them in the configuration file.
 
     .. tip::
 
-        This can be be set contextually with the environment variable
+        This can be set contextually with the environment variable
         ``EXOSPHERE_OPTIONS_NO_BANNER`` set to ``true``.
         For more details see :ref:`config_env_vars`.
 
@@ -1135,7 +1135,7 @@ Inventory
 ---------
 
 The second section of the configuration file is the `Hosts` section, which is
-referred throughout the documentation as **The Inventory**.
+referred to throughout the documentation as **The Inventory**.
 
 The `Hosts` section contains a list of hosts that Exosphere will connect to, as well
 as their connection parameters and any specific option for each host.

--- a/docs/source/connections.rst
+++ b/docs/source/connections.rst
@@ -23,10 +23,10 @@ are as follows:
 
 .. admonition:: Note
 
-    Exosphere will (through Fabric) absolutely load and honor ssh client configurations
+    Exosphere will (through Fabric) absolutely load and honor SSH client configurations
     from ``~/.ssh/config`` or ``/etc/ssh/ssh_config`` if they exist.
 
-    This means you can set up advanced SSH options, such as host aliases, per-host ssh keys
+    This means you can set up advanced SSH options, such as host aliases, per-host SSH keys
     and even gateways, without relying on Exosphere to provide the functionality you need.
 
 Using SSH Agents
@@ -34,7 +34,7 @@ Using SSH Agents
 
 An SSH agent is a program that loads your SSH keys into memory, usually with your login session
 on your workstation or laptop, allowing you to connect to remote hosts without having to
-enter your passphrase every time. This is instrumental to many ssh automation tools and
+enter your passphrase every time. This is instrumental to many SSH automation tools and
 workflows.
 
 Exosphere relies on the SSH agent to provide the necessary keys for authentication.
@@ -193,7 +193,7 @@ exosphere CLI and its ``sudo`` command. Here is an example below:
     └──────────┴────────────────────────────────┴───────────────────┴─────────────────┘
 
 For instance, we can see here that the ``Apt`` and ``Pkg`` providers require sudo privileges
-to sync repositories, but does not require any privileges to refresh updates.
+to sync repositories, but do not require any privileges to refresh updates.
 
 .. note::
    The table above shows the privilege requirements for each operation type:

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -24,7 +24,7 @@ Yes, as long as the remote system is a Unix-like operating system.
 In this case, if your remote operating system is not supported, Exosphere will allow
 you to use the dashboard and online checks (ping command, etc) just fine.
 
-You won't be able to perform refresh or sync operation on them, and the update
+You won't be able to perform refresh or sync operations on them, and the update
 counts will be disabled, but this part will remain functional.
 
 If the system in question is not a Unix-like operating system, it will not
@@ -78,7 +78,7 @@ Verify that:
 
 The unhelpful error message is unfortunately `Known Issue`_ in the `paramiko`
 library, which is used internally to handle SSH connections. Whenever
-authentication fails when a SSH agent is used, this is the exception
+authentication fails when an SSH agent is used, this is the exception
 that will be raised, regardless of the actual issue.
 
 Exosphere will generally catch this specific error and rewrite the error message
@@ -141,7 +141,7 @@ without write access errors afterwards.
 I've tuned the timeout but this one host keeps getting flagged offline
 ----------------------------------------------------------------------
 
-Exosphere does use a fairly aggressive timeout value for its ssh connections,
+Exosphere does use a fairly aggressive timeout value for its SSH connections,
 but if you have a host that is consistently supremely slow to respond, yet you
 can connect to it reliably, it is likely you have DNS issues on that server.
 
@@ -250,7 +250,7 @@ them as a synthetic package in the updates view, but this needs more work.
 For the time being, cron reports and mailing lists for `syspatch` and
 `freebsd-update` are recommended to keep tabs on these.
 
-Does FreeBSD support extends to things like OPNSense?
+Does FreeBSD support extend to things like OPNSense?
 -----------------------------------------------------
 
 Since **1.3.4**, the ``pkg`` provider performs repository synchronization in a
@@ -281,7 +281,7 @@ The usual checklist for files in sudoers.d applies here:
 - Must not contain syntax errors (check with `visudo -c -f /etc/sudoers.d/yourfile`)
 
 If you are still having issues, a common problem is another rule matching last.
-Sudo reads rules in lexicographic order (i.e not strictly alphabetical), but does not
+Sudo reads rules in lexicographic order (i.e., not strictly alphabetical), but does not
 merge them, and the last matching rule wins.
 
 You can verify ordering with `visudo -c` and find out which rule is matching
@@ -289,7 +289,7 @@ last with:
 
 .. code-block:: bash
 
-    sudo -l -U youruser /the/sudo/commmand --and --args
+    sudo -l -U youruser /the/sudo/command --and --args
 
 and compare with the output of ``sudo -ll`` to see which rule matched vs which was expected.
 
@@ -319,7 +319,7 @@ or override via :ref:`environment variables <config_env_vars>`, if feasible.
 Is Windows support planned or even possible?
 ------------------------------------------------
 
-The application runs fine on windows, and while managing Windows is something we would love
+The application runs fine on Windows, and while managing Windows is something we would love
 to implement, the connection methods are not incredibly straightforward, and the APIs and
 interfaces for update and patch management are not great. Microsoft continues to hope you
 will buy into their management tools, so the core APIs are not very accessible as a result.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -9,7 +9,7 @@ Host
     in the inventory.
 
 Inventory
-    The inventory is the collection of Hosts that exosphere knows about.
+    The inventory is the collection of Hosts that Exosphere knows about.
     It is defined through the configuration file, in the Hosts section.
     Commands and functions that operate on the inventory will generally
     target All Hosts.
@@ -23,7 +23,7 @@ Provider
     automatically detected based on the platform.
 
 Update
-    An Update, within exosphere, is an object representing a package that has
+    An Update, within Exosphere, is an object representing a package that has
     a new version available for installation.
 
 Security
@@ -54,11 +54,11 @@ Refresh
     into a single operation depending on context.
 
 Repositories
-    The Repositories are the generic term for the authoritative list of packages on the
-    host platform. This generally consists of repositories. For instance, on Debian
-    and Ubuntu systems, the repositories refer to the remote systems configured in
-    `/etc/apt/sources.list` and friends. On RedHat-likes, it refers to the
-    repositories configured in `/etc/yum.repos.d/` and so on.
+    Repositories is the generic term for the authoritative list of packages on the
+    host platform. For instance, on Debian and Ubuntu systems, it refers
+    to the remote systems configured in `/etc/apt/sources.list` and friends.
+    On RedHat-likes, it refers to the repositories configured in `/etc/yum.repos.d/`,
+    and so on.
 
 Repository Sync
     Synchronizing the repositories is the process of updating the local host cache

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,13 +24,13 @@ If you have SSH access to the hosts with an `agent`_, you are good to go!
 - Consistent view across different platforms and package managers
 - See everything in one spot, at a glance, without complex automation
   or enterprise solutions.
-- Document based reporting in HTML, text or markdown format
+- Document-based reporting in HTML, text or markdown format
 - JSON output available for integration with other tools
 
 
 **Compatibility**
 
-- **Exosphere**: Linux, BSDs, MacOS, Windows (and more!)
+- **Exosphere**: Linux, BSDs, macOS, Windows (and more!)
 - **Remote**: Debian/Ubuntu-likes, RedHat-Likes, FreeBSD, OpenBSD
 
 .. note::

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,7 +14,7 @@ the following platforms:
 
 - Linux (any)
 - FreeBSD
-- MacOS
+- macOS
 - Windows
 
 Platform specific notes will appear whenever relevant, but the process
@@ -93,8 +93,8 @@ Installing from Git Repository
 This is likely the easiest method if you want to track the latest development
 version, or are simply more comfortable with using Git.
 
-The project is setup with `uv`_, which will download and install the necessary
-python runtime and dependencies for you, so you don't have to worry about
+The project is set up with `uv`_, which will download and install the necessary
+Python runtime and dependencies for you, so you don't have to worry about
 any of this.
 
 You will require the following tools installed:
@@ -102,7 +102,7 @@ You will require the following tools installed:
 - `git`_ - to clone the repository
 - `uv`_ - to install the application and manage its dependencies
 
-First, Clone the repository into a directory of your choice.
+First, clone the repository into a directory of your choice.
 
 .. tabs::
 
@@ -139,7 +139,7 @@ If you want the stable version, you can switch to the latest tag.
             git checkout |CurrentVersionTag|
 
         You can substitute |CurrentVersionTag| with a specific tag or
-        version to use a specific release, e.g, `v0.8.1`.
+        version to use a specific release, e.g., `v0.8.1`.
 
         You can find the list of tags on the `GitHub releases page`_.
 
@@ -157,7 +157,7 @@ If you want the stable version, you can switch to the latest tag.
             git checkout main
 
 
-Once that is done, you can simply setup Exosphere using `uv`_:
+Once that is done, you can simply set up Exosphere using `uv`_:
 
 .. code-block:: text
 
@@ -176,7 +176,7 @@ Exosphere directly:
 
 .. tabs::
 
-    .. group-tab:: Unix/MacOS
+    .. group-tab:: Unix/macOS
 
         .. code-block:: text
 
@@ -274,7 +274,7 @@ pulling the latest changes and then syncing with `uv`_:
             uv sync --no-dev
 
         You can substitute |CurrentVersionTag| with the latest tag or
-        specific version you want to use, e.g, `v0.8.1`.
+        specific version you want to use, e.g., `v0.8.1`.
 
         You can find the list of tags on the `GitHub releases page`_.
 

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -30,7 +30,7 @@ and **does not** require elevated privileges.
     `Unattended Upgrades`_ to achieve this on a schedule.
 
 
-Exact Commands ran on remote hosts
+Exact Commands run on remote hosts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``/usr/bin/apt-get update`` **(requires sudo)**
@@ -61,7 +61,7 @@ as the connection user to retrieve the information.
 Updates retrieval is done using ``yum/dnf check-update``, and does *not* require
 elevated privileges.
 
-Exact Commands ran on remote systems
+Exact Commands run on remote systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
@@ -127,7 +127,7 @@ to configure sudo privileges for Exosphere.
 Updates retrieval is done using ``pkg upgrade`` in simulation mode, and **does not**
 require elevated privileges.
 
-Exact Commands ran on remote systems
+Exact Commands run on remote systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``/usr/sbin/pkg update -q`` **(requires sudo)**
@@ -172,11 +172,11 @@ Limitations
 - Handles transitive dependencies without marking them as such, and may,
   in some edge cases, list more packages than strictly necessary for an update.
 
-Exact Commands ran on remote systems
+Exact Commands run on remote systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``/usr/sbin/syspatch -l``
-- ``/usr/sbin/pkg_add -u -v -x -n | grep -e '^Update candidate'"``
+- ``/usr/sbin/pkg_add -u -v -x -n | grep -e '^Update candidate'``
 
 Command dependencies
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/reporting.rst
+++ b/docs/source/reporting.rst
@@ -6,9 +6,9 @@ detailed reports of your inventory status and system updates in multiple formats
 
 This functionality **does not require any connectivity or live access to hosts**
 and operates entirely from the Cache, allowing reports or json to be exported on
-a schedule or from a different context where your ssh agent is not available.
+a schedule or from a different context where your SSH agent is not available.
 
-The only requirement is read access to the exosphere cache database.
+The only requirement is read access to the Exosphere cache database.
 (See :doc:`cachefile` for more details.)
 
 
@@ -130,7 +130,7 @@ arguments. For example, to generate a JSON report for just three hosts:
 
 **Updates Available Only**
 
-The report can filtered to only show hosts with updates available using
+The report can be filtered to only show hosts with updates available using
 ``--updates-only``:
 
 .. code-block:: shell
@@ -264,7 +264,7 @@ Integration Examples
 Here are some concrete but deeply uncreative examples of how the reporting
 feature can be used in practice.
 
-If you make a cool thing, please `let us know`_ via a github issue!
+If you make a cool thing, please `let us know`_ via a GitHub issue!
 We'll happily showcase it here.
 
 **Email text report about security updates**

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -14,13 +14,13 @@ There are two tiers of effective support in Exosphere.
    Exosphere is limited to basic SSH connectivity checks and presence in
    the dashboard.
 
-Platform support for Patches and Updates are implemented via an extensible
+Platform support for Patches and Updates is implemented via an extensible
 provider system, which allows for new platforms to be added in the future.
 
 **If your remote operating system does not have a provider**, you can still use
 Exosphere for the basic SSH ping connectivity checks and Dashboard. They will
 show up in the inventory, but no patch and update reporting features will be available,
-*as long as it is a unix-like operating system and obeys basic POSIX standards.*
+*as long as it is a Unix-like operating system and obeys basic POSIX standards.*
 
 Unfortunately, this excludes exotic things such as Windows, routers with SSH enabled
 but proprietary, non-Unix-like operating systems, etc. Discovery will not work at all
@@ -50,7 +50,7 @@ Compatibility List
 
 .. admonition:: note
 
-   FreeBSD Optionally requires the ``sudo`` package for repository sync operations.
+   FreeBSD optionally requires the ``sudo`` package for repository sync operations.
    Unfortunately ``doas`` is not supported at this time.
 
 

--- a/docs/source/ui.rst
+++ b/docs/source/ui.rst
@@ -5,7 +5,7 @@ The Text User Interface of Exosphere provides a visual, interactive way of
 accessing the information gathered by Exosphere across your hosts.
 
 It is a modal interface comprised of several screens you can toggle between,
-and allows you perform actions such as:
+and allows you to perform actions such as:
 
 - Viewing the status of all hosts in a Dashboard
 - Viewing the inventory status and drilling down into host details

--- a/docs/source/webui.rst
+++ b/docs/source/webui.rst
@@ -79,7 +79,7 @@ to access the WebUI.
 .. image:: /_static/webui_sample.png
    :alt: Example of Exosphere WebUI
 
-The controls are the exact same as the documented in the :doc:`ui` documentation, so you can
+The controls are the exact same as those documented in the :doc:`ui` documentation, so you can
 use the same keybinds and commands to navigate and perform operations.
 
 The mouse can also be used to select elements from the interface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "sphinx-tabs>=3.4.7",
     "sphinxcontrib-spelling>=8.0.2",
     "textual-dev>=1.7.0",
+    "codespell>=2.4.0",
 ]
 
 [project.optional-dependencies]
@@ -82,6 +83,9 @@ module-name = "exosphere"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.codespell]
+skip = "*.lock,*.woff,*.woff2,*.ttf,*.ttx,*.svg,*.png,*.gif,*.html,*.htm,docs/source/_static"
+
 [tool.poe.tasks]
 lint = "ruff check src tests scripts"
 isort = "ruff check --select I --fix src tests scripts"
@@ -89,9 +93,11 @@ isort-check = "ruff check --select I src tests scripts --diff"
 typecheck = "pyright src tests scripts"
 ruff-format = "ruff format src tests scripts"
 ruff-format-check = "ruff format --check src tests scripts --diff"
+spellcheck = "codespell src tests scripts docs/source README.md"
+spellcheck-fix = "codespell --write-changes src tests scripts docs/source README.md"
 format = ['ruff-format', 'isort']
 format-check = ['ruff-format-check', 'isort-check']
-check = ['format-check', 'lint', 'typecheck']
+check = ['format-check', 'lint', 'typecheck', 'spellcheck']
 test = "pytest -v --ctrf .tests_report.json"
 coverage = "pytest --cov-report term-missing --cov-report html --cov=src tests/"
 docs-build = "sphinx-build -b html docs/source docs/build/html" 

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -61,10 +61,10 @@ def discover(*names: HostArg) -> int:
     """
     Gather platform information for hosts
 
-    On a fresh inventory start, this needs done at least once before
-    operations can be performed on the hosts. It can also be used to
-    refresh this information if it has changed, or if a new provider
-    has been added to Exosphere.
+    On a fresh inventory start, this needs to be done at least once
+    before operations can be performed on the hosts. It can also be
+    used to refresh this information if it has changed, or if a new
+    provider has been added to Exosphere.
 
     The discover operation will connect to the specified host(s)
     and gather their current state, including Operating System, flavor,

--- a/src/exosphere/providers/openbsd.py
+++ b/src/exosphere/providers/openbsd.py
@@ -20,7 +20,7 @@ class PkgAdd(PkgManager):
           as it then behaves like a rolling release and there is no way to tell
         - On stable/release, all updates are assumed to be security updates,
           as OpenBSD only ever updates packages for security issues.
-        - Thouroughly untested on more exotic architectures where syspatch
+        - Thoroughly untested on more exotic architectures where syspatch
           may not be available or fail in different ways. Bug reports welcome!
     """
 

--- a/src/exosphere/ui/app.py
+++ b/src/exosphere/ui/app.py
@@ -39,7 +39,7 @@ class ExosphereUi(App):
     as well as the status bar setup and composition.
 
     Since it manages the modal screen state, it is also responsible
-    for tracking which screens need refreshed when the shared data
+    for tracking which screens need to be refreshed when the shared data
     changes via the message system.
     """
 
@@ -78,7 +78,7 @@ class ExosphereUi(App):
         """
         Dispatch a host operation off the UI thread, refresh screens.
 
-        Handles pushing a :class:`ProgressScreen` to run the the
+        Handles pushing a :class:`ProgressScreen` to run the
         ``operation`` on the given hosts (or all hosts, when unspecified).
 
         On completion, unless a custom ``callback`` is specified, runs

--- a/src/exosphere/ui/palette.py
+++ b/src/exosphere/ui/palette.py
@@ -117,7 +117,7 @@ class HostCommandProvider(_PaletteProvider):
 
     Hits are score-boosted so they appear above the global
     providers' entries (so the selected host shortcut is at the top
-    of the results, but burried at the bottom of the palette).
+    of the results, but buried at the bottom of the palette).
     """
 
     BOOST = 100.0

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -248,8 +248,8 @@ class TestStatusCommand:
         assert code == 0
         assert "host8" in out
         assert "exotic-os" in out
-        assert "(unsupport" in out  # May be truncated depending on width
-        assert out.count("(unsupport") == 2
+        assert "(unsupport" in out  # Truncated ; codespell:ignore unsupport
+        assert out.count("(unsupport") == 2  # codespell:ignore unsupport
         assert out.count("—") == 2
 
     @pytest.mark.parametrize("flag", ["--full", "-f"], ids=["long", "short"])

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -349,7 +349,7 @@ class TestPkgProvider:
 
         # Context manager behavior should return the same mock
         mock_cx.__enter__.return_value = mock_cx
-        mock_cx.__exit__.return_value = False  # Don't supress exceptions
+        mock_cx.__exit__.return_value = False  # Don't suppress exceptions
 
         # Default to successful run
         mock_cx.run.return_value.failed = False
@@ -751,7 +751,7 @@ class TestPkgAddProvider:
 
         # Context manager behavior should return the same mock
         mock_cx.__enter__.return_value = mock_cx
-        mock_cx.__exit__.return_value = False  # Don't supress exceptions
+        mock_cx.__exit__.return_value = False  # Don't suppress exceptions
 
         # Default to successful run
         mock_cx.run.return_value.failed = False
@@ -1219,7 +1219,7 @@ class TestDnfProvider:
 
         # Context manager behavior should return the same mock
         mock_cx.__enter__.return_value = mock_cx
-        mock_cx.__exit__.return_value = False  # Don't supress exceptions
+        mock_cx.__exit__.return_value = False  # Don't suppress exceptions
 
         mock_cx.run.return_value.failed = False
         return mock_cx

--- a/tests/ui/test_integration.py
+++ b/tests/ui/test_integration.py
@@ -171,7 +171,7 @@ async def test_sort_screen_list_matches_sortfield():
 
     This assumption is essentially baked into the SortScreen's behavior
     This test is meant to trip if that assumption breaks, and the
-    entries are out of sync/misaligned, and this needs fixed.
+    entries are out of sync/misaligned, and this needs to be fixed.
 
     For the future generations reading this test wondering why
     it's red, and why this idiot didn't dynamically generate

--- a/tests/ui/test_logs.py
+++ b/tests/ui/test_logs.py
@@ -78,7 +78,7 @@ class TestRichLogFormatter:
         assert "(pockets3)" in out
 
     def test_log_formatting_still_applies(self):
-        """Deliberate formatting in non message elemnts should remain"""
+        """Deliberate formatting in non-message elements should remain"""
         formatted = RichLogFormatter().format(self._make_record("SPAGHETT!"))
         level_color = RichLogFormatter.LEVEL_COLORS["WARNING"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -346,6 +346,15 @@ wheels = [
 ]
 
 [[package]]
+name = "codespell"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9d/1d0903dff693160f893ca6abcabad545088e7a2ee0a6deae7c24e958be69/codespell-2.4.2.tar.gz", hash = "sha256:3c33be9ae34543807f088aeb4832dfad8cb2dae38da61cac0a7045dd376cfdf3", size = 352058, upload-time = "2026-03-05T18:10:42.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/a1/52fa05533e95fe45bcc09bcf8a503874b1c08f221a4e35608017e0938f55/codespell-2.4.2-py3-none-any.whl", hash = "sha256:97e0c1060cf46bd1d5db89a936c98db8c2b804e1fdd4b5c645e82a1ec6b1f886", size = 353715, upload-time = "2026-03-05T18:10:41.398Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +560,7 @@ web = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "codespell" },
     { name = "fabric", extra = ["pytest"] },
     { name = "jsonschema" },
     { name = "poethepoet" },
@@ -588,6 +598,7 @@ provides-extras = ["web"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codespell", specifier = ">=2.4.0" },
     { name = "fabric", extras = ["pytest"], specifier = ">=3.2.2" },
     { name = "jsonschema", specifier = ">=4.25.1" },
     { name = "poethepoet", specifier = ">=0.33.1" },


### PR DESCRIPTION
## Fix typos and grammatical errors in the codebase
    
Armed with codespell, a bunch of dictionary utilities and many, many rounds of review, I have fixed a large number of typos and grammatical errors across the codebase and documentation.
    
Some of these were embarrassing, in public, live documentation, and I'm not sure how they remained undetected for so long.
    
Others were part of docstrings and comments, and while they were not visible to users, they were still horrifying and again, I don't know how they stayed undetected for so many commits.

One section of the documentation (glossary) had particularly terrible wording, which is just 100% on me constructing a terrible sentence in the first place, and so that has been reworded and cleaned up.
    
Additionally, it turns out that I use the dialectal form "noun needs verbed" a lot, which I blame a scottish friend for, and after some research, relented and "fixed" those to be grammatically correct, even though I was very fond of the original.
    
This took forever, and was long overdue.
    
(Ironically, I'm sure you can find a typo in this commit message)

## Add codespell, poe tasks, gate check
    
Because I make an absurd amount of typos apparently, that my brain simply refuses to see when re-reading 60 times even in production, this change adds codespell to the project dev dependencies, and adds the following poe tasks:
    
- "poe spellcheck" to run codespell on the project, including scripts and docs
- "poe spellcheck-fix" to run codespell with the --write-changes flag
    
"spellcheck" has been added to the general "check" task, which is more or less the gate check for the project, so that is now automagically run in CI, and also a thing I run locally before commits.

Hopefully, it will help prevent me from making the same typo 4 times in a row, very consistently, and somehow not seeing it at all.