### PR TITLE
Add "macOS" to docs wordlist

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -34,6 +34,7 @@ keybinds
 kwargs
 linux
 lstrip
+macOS
 MiB
 misconfiguration
 nopasswd


### PR DESCRIPTION
It is how it is canonically spelled, and doesn't trigger the same across platforms.