### PR TITLE
Config: Add stricter schema validation

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -429,7 +429,7 @@ and examples of how to set them in the configuration file.
     ``log_max_bytes * (log_backup_count + 1)``.
 
     This must be a positive integer of ``1`` or more, any lower value is
-    simply clamped to ``1``, and a warning is logged.
+    rejected as invalid.
 
     To disable rotation entirely, set :option:`log_max_bytes` to ``0`` instead.
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -58,6 +58,7 @@ subclass
 subclasses
 subcommand
 subcommands
+subtree
 sudo
 sudoers
 syspatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev11"
+version = "3.0.0.dev12"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [
@@ -36,6 +36,7 @@ dependencies = [
     "rich>=14.1.0",
     "cyclopts>=4.16.1",
     "filelock>=3.29.4",
+    "pydantic>=2.12",
 ]
 
 [dependency-groups]

--- a/src/exosphere/commands/config.py
+++ b/src/exosphere/commands/config.py
@@ -265,7 +265,7 @@ def edit(
         try:
             validate_config(target)
         except Exception as e:
-            err_console.print(f"[red]Configuration is invalid:[/red] {e}")
+            err_console.print(f"[red]Configuration is invalid:[/red]\n{e}")
             if Confirm.ask("Re-open editor to fix?", default=True):
                 continue
             err_console.print(

--- a/src/exosphere/config.py
+++ b/src/exosphere/config.py
@@ -7,22 +7,227 @@ import os
 import tomllib
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Annotated, Any, BinaryIO, ClassVar
 
 import yaml
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from exosphere import fspaths
+from exosphere.security import SudoPolicy
 
-#: A mapping of the known configuration loaders available out of the box
-#: for the Exosphere configuration system, keyed by file extension.
-#: The configuration system technically allows for any loader callable
-#: to be used, but these are the ones that are wired in by default.
+# A mapping of the known configuration loaders available out of the box
+# for the Exosphere configuration system, keyed by file extension.
+# The configuration system technically allows for any loader callable
+# to be used, but these are the ones that are wired in by default.
 KNOWN_LOADERS: dict[str, Callable[..., Any]] = {
     "yaml": yaml.safe_load,
     "yml": yaml.safe_load,
     "toml": tomllib.load,
     "json": json.load,
 }
+
+
+def _normalize_sudo_policy(value: str) -> str:
+    """Validate and normalize a sudo policy name."""
+    candidate = value.lower()
+    valid_values = {policy.value for policy in SudoPolicy}
+    if candidate not in valid_values:
+        valid = ", ".join(sorted(valid_values))
+        raise ValueError(f"invalid sudo policy {value!r}; must be one of: {valid}")
+
+    return candidate
+
+
+# Reusable string type that normalizes/validates a sudo policy name.
+SudoPolicyName = Annotated[str, AfterValidator(_normalize_sudo_policy)]
+
+# Reusable string type for fields where an empty value is always a mistake
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class OptionsModel(BaseModel):
+    """
+    Schema for the Exosphere options (global runtime settings) section.
+
+    This is the authoritative source of truth for option keys and
+    defaults within the Exsophere configuration subsystem.
+
+    :attr:`Configuration.DEFAULTS` is derived from this schema.
+
+    Unknown keys are rejected with a ValueError, and all values are
+    validated and normalized to canonical form, if applicable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Maintained list of Deprecated Options, with a guidance message
+    # Deprecated options are tolerated in the schema, but a warning
+    # is logged when they are encountered.
+    DEPRECATED_OPTIONS: ClassVar[dict[str, str]] = {
+        # "old_option": "removed in 3.1; use 'new_option' instead",
+    }
+
+    # Valid logging level names accepted by the ``log_level`` option.
+    VALID_LOG_LEVELS: ClassVar[frozenset[str]] = frozenset(
+        {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+    )
+
+    debug: bool = False  # Debug mode, enable verbose on root logger
+    log_level: str = "INFO"  # Default log level for the application
+    log_file: str = Field(  # Default log file for the application
+        default_factory=lambda: str(fspaths.LOG_DIR / "exosphere.log")
+    )
+    log_max_bytes: int = Field(  # Rotate log file past this size (5 MiB)
+        default=5 * 1024 * 1024, ge=0
+    )
+    log_backup_count: int = Field(default=3, ge=1)  # Rotated log files to keep.
+    history_file: str = Field(  # Default history file for the repl
+        default_factory=lambda: str(fspaths.STATE_DIR / "repl_history")
+    )
+    history_max_entries: int = Field(  # Trim repl history to this many entries
+        default=1000, ge=0
+    )
+    cache_autosave: bool = True  # Automatically save cache to disk after changes
+    cache_autopurge: bool = True  # Automatically purge hosts removed from inventory
+    cache_file: str = Field(  # Default cache file for the application
+        default_factory=lambda: str(fspaths.STATE_DIR / "exosphere.db")
+    )
+    stale_threshold: int = Field(  # How long before a host is considered stale
+        default=86400, ge=0
+    )
+    default_timeout: int = Field(  # Default ssh connection timeout (in seconds)
+        default=10, ge=1
+    )
+    default_username: NonEmptyStr | None = None  # Default global SSH username
+    default_sudo_policy: SudoPolicyName = "skip"  # Global sudo policy for pkg ops
+    max_threads: int = Field(default=15, ge=1)  # Max threads for parallel ops
+    ssh_pipelining: bool = False  # Enable SSH pipelining for SSH connections
+    ssh_pipelining_lifetime: int = Field(  # Max lifetime (secs) of SSH connections
+        default=300, ge=1
+    )
+    ssh_pipelining_reap_interval: int = Field(  # Interval (secs) between reaper checks
+        default=30, ge=1
+    )
+    update_checks: bool = True  # Set to false if you want to disable PyPI checks
+    no_banner: bool = False  # Disable the REPL banner on startup
+    editor: NonEmptyStr | None = None  # Editor command for `config edit`
+
+    @model_validator(mode="before")
+    @classmethod
+    def drop_deprecated(cls, data: Any) -> Any:
+        # Pop intentionally-removed options with a warning before
+        # validation runs, so old configs survive upgrades while
+        # actual mistakes are still fatal.
+        if isinstance(data, dict):
+            logger = logging.getLogger(__name__)
+            for key in cls.DEPRECATED_OPTIONS.keys() & data.keys():
+                logger.warning(
+                    "Configuration option '%s' is no longer used (%s), ignoring.",
+                    key,
+                    cls.DEPRECATED_OPTIONS[key],
+                )
+                data = {k: v for k, v in data.items() if k != key}
+        return data
+
+    @field_validator("log_level")
+    @classmethod
+    def validate_log_level(cls, value: str) -> str:
+        candidate = value.upper()
+        if candidate not in cls.VALID_LOG_LEVELS:
+            valid = ", ".join(sorted(cls.VALID_LOG_LEVELS))
+            raise ValueError(f"invalid log level {value!r}; must be one of: {valid}")
+        return candidate
+
+    @model_validator(mode="after")
+    def validate_reaper_interval(self) -> "OptionsModel":
+        if self.ssh_pipelining_reap_interval > self.ssh_pipelining_lifetime:
+            raise ValueError(
+                "ssh_pipelining_reap_interval cannot be greater than "
+                "ssh_pipelining_lifetime"
+            )
+        return self
+
+
+class HostModel(BaseModel):
+    """
+    Schema for a host entry in the ``hosts`` configuration section.
+
+    Parameters very much line up with :class:`exosphere.objects.Host`,
+    and this is on purposes, but unknown keys are ignored (with a
+    warning) rather than rejected, to keep this section more forgiving
+    of typos and legacy options across upgrades and migrations.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: NonEmptyStr
+    ip: NonEmptyStr
+    port: int = Field(default=22, ge=1, le=65535)
+    username: NonEmptyStr | None = None
+    description: str | None = None
+    connect_timeout: int | None = Field(default=None, ge=1)
+    sudo_policy: SudoPolicyName | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_unknown_keys(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            unknown = set(data) - set(cls.model_fields)
+            if unknown:
+                name = data.get("name", "(unnamed)")
+                logger = logging.getLogger(__name__)
+                for key in sorted(unknown):
+                    logger.warning(
+                        "Unknown host configuration option '%s' for host '%s', "
+                        "ignoring.",
+                        key,
+                        name,
+                    )
+        return data
+
+    @field_validator("ip")
+    @classmethod
+    def validate_ip(cls, value: str) -> str:
+        # IP field cannot contain '@' character.
+        # SSH library will interpret this as a username, which will
+        # result in a lot of exciting "undefined behaviors".
+        if "@" in value:
+            raise ValueError(
+                "'@' character is not allowed in hostname or ip. "
+                "Use the 'username' option to specify a username"
+            )
+        return value
+
+
+class ConfigModel(BaseModel):
+    """
+    Top-level configuration schema, combining global options and the host
+    inventory. Used to validate and normalize the configuration as a whole.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    options: OptionsModel = Field(default_factory=OptionsModel)
+    hosts: list[HostModel] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def unique_host_names(self) -> "ConfigModel":
+        names = [host.name for host in self.hosts]
+        dupes = sorted({name for name in names if names.count(name) > 1})
+        if dupes:
+            raise ValueError(
+                f"Duplicate host names found in configuration: {', '.join(dupes)}"
+            )
+        return self
 
 
 def validate(file: str | Path) -> None:
@@ -59,6 +264,8 @@ class Configuration(dict):
     - Enforces unicity for name keys in the ``hosts`` dict.
     - Has a :meth:`deep_update` method to recursively update nested dicts
       without replacing them entirely.
+    - Is entirely self-validating and normalizing, using a pydantic
+      schema to ensure the configuration is always in a valid state
 
     This configuration structure is strongly inspired by the one used
     by Flask, because good things are worth replicating.
@@ -67,37 +274,10 @@ class Configuration(dict):
     #: Default configuration values
     #: This dict contains the default configuration and is always
     #: used as a base for what the configuration object contains.
-    #: This can be accessed to get the default values for any config key
+    #: This can be accessed to get the default values for any config key.
+    #: It is derived directly from the :class:`OptionsModel` schema.
     DEFAULTS: dict[str, Any] = {
-        "options": {
-            "debug": False,  # Debug mode, enable verbose on root logger
-            "log_level": "INFO",  # Default log level for the application
-            "log_file": str(
-                fspaths.LOG_DIR / "exosphere.log"
-            ),  # Default log file for the application
-            "log_max_bytes": 5 * 1024 * 1024,  # Rotate log file past this size (5 MiB)
-            "log_backup_count": 3,  # Number of rotated log files to keep
-            "history_file": str(
-                fspaths.STATE_DIR / "repl_history"
-            ),  # Default history file for the repl
-            "history_max_entries": 1000,  # Trim repl history to this many entries
-            "cache_autosave": True,  # Automatically save cache to disk after changes
-            "cache_autopurge": True,  # Automatically purge hosts removed from inventory
-            "cache_file": str(
-                fspaths.STATE_DIR / "exosphere.db"
-            ),  # Default cache file for the application
-            "stale_threshold": 86400,  # How long before a host is considered stale
-            "default_timeout": 10,  # Default ssh connection timeout (in seconds)
-            "default_username": None,  # Default global username to use for SSH
-            "default_sudo_policy": "skip",  # Global sudo policy for package manager ops
-            "max_threads": 15,  # Maximum number of threads to use for parallel ops
-            "ssh_pipelining": False,  # Enable SSH pipelining for SSH connections
-            "ssh_pipelining_lifetime": 300,  # Max lifetime (secs) of SSH connections
-            "ssh_pipelining_reap_interval": 30,  # Interval (secs) between reaper checks
-            "update_checks": True,  # Set to false if you want to disable PyPI checks
-            "no_banner": False,  # Disable the REPL banner on startup
-            "editor": None,  # Editor command for `config edit` ($VISUAL/$EDITOR if unset)
-        },
+        "options": OptionsModel().model_dump(),
         "hosts": [],
     }
 
@@ -134,11 +314,17 @@ class Configuration(dict):
         but you can specify a custom loader function to parse the values,
         as long as it operates on strings.
 
+        Invalid keys or values will be be ignored and logged as
+        warnings, and nested dictionary keys will have their entire
+        subtree dropped if any of the leaves are invalid.
+
         :param prefix: The prefix to look for in environment variables
         :param parser: A callable that takes a string and returns a parsed value
         :return: True if the configuration was successfully updated
         """
         prefix = prefix.upper() + "_"
+
+        options: dict[str, Any] = {}
 
         for key in os.environ:
             if not key.startswith(prefix):
@@ -162,7 +348,7 @@ class Configuration(dict):
                     self.logger.debug(
                         "Updating configuration key from env %s: %s", key, value
                     )
-                    self["options"][key] = value
+                    options[key] = value
                 else:
                     self.logger.warning(
                         "Configuration key %s is not a valid options key, ignoring", key
@@ -170,7 +356,7 @@ class Configuration(dict):
                 continue
 
             # We have a nested key
-            current = self["options"]
+            current = options
             *parent_keys, leaf_key = key.split("__")
 
             for parent in parent_keys:
@@ -182,7 +368,82 @@ class Configuration(dict):
 
             current[leaf_key] = value
 
-        return True
+        # Environment overrides are best effort - unlike a config file
+        # they really are just an amalgamation of transient overrides
+        # leaking from the ceiling of the building where the app is
+        # running.
+        #
+        # Invalid values are therefore ignored and logged as warnings
+        # rather than aborting startup. Try the whole batch first (the common
+        # case, one validation); only if that fails do we figure out which
+        # overrides are bad and drop them, keeping the rest.
+        try:
+            return self.update_from_mapping({"options": options})
+        except Exception:
+            # Fall through to best-effort recovery below. A bad env override
+            # must never be fatal, so we deliberately swallow anything here.
+            self.logger.debug(
+                "Environment overrides failed validation, falling back to best-effort"
+            )
+
+        # Drop offending overrides until the remainder validates.
+        # Candidate set is validated as a batch for two reasons:
+        #
+        # 1. Options sharing a joint constraint are checked together,
+        #    so an override that is valid only because of another
+        #    specified override is not dropped by being checked on
+        #    their own.
+        # 2. Avoids systematically running the validation on each key
+        #
+        candidate = dict(options)
+        while candidate:
+            try:
+                OptionsModel.model_validate({**self["options"], **candidate})
+                break
+            except ValidationError as exc:
+                self._drop_invalid_env_overrides(candidate, exc)
+
+        return self.update_from_mapping({"options": candidate})
+
+    def _drop_invalid_env_overrides(
+        self, candidate: dict[str, Any], exc: ValidationError
+    ) -> None:
+        """
+        Remove invalid config overrides from candidate based on Exception
+
+        :param candidate: Mapping of pending overrides, mutated in place.
+        :param exc: The validation error to attribute and report.
+        """
+        reasons: dict[str, list[str]] = {}
+        unattributable: list[str] = []
+
+        for error in exc.errors():
+            loc = error["loc"]
+
+            # Strip pydantic's "Value error, " prefix from custom validators
+            message = error["msg"].removeprefix("Value error, ")
+
+            if loc and loc[0] in candidate:
+                reasons.setdefault(str(loc[0]), []).append(message)
+            else:
+                unattributable.append(message)
+
+        culprits = set(reasons) or set(candidate)
+
+        for key in sorted(culprits):
+            value = candidate.pop(key)
+
+            subtree = (
+                " (entire nested subtree dropped)" if isinstance(value, dict) else ""
+            )
+            detail = "; ".join(reasons.get(key, unattributable))
+
+            self.logger.warning(
+                "Ignoring invalid environment override for '%s'%s: %s",
+                key,
+                subtree,
+                detail,
+            )
 
     def from_toml(self, filepath: str, silent: bool = False) -> bool:
         """
@@ -293,6 +554,22 @@ class Configuration(dict):
 
         return self.update_from_mapping(data)
 
+    def deep_update(self, d: dict, u: dict) -> dict:
+        """
+        Recursively update a dictionary with another dictionary.
+        Ensures nested dicts are updated rather than replaced.
+
+        :param d: The dictionary to update
+        :param u: The dictionary with updates
+        :return: The updated dictionary
+        """
+        for k, v in u.items():
+            if isinstance(v, dict) and k in d and isinstance(d[k], dict):
+                self.deep_update(d[k], v)
+            else:
+                d[k] = v
+        return d
+
     def update_from_mapping(self, *mapping: dict, **kwargs: dict) -> bool:
         """
         Populate values like the native `dict.update()` method, but
@@ -300,6 +577,10 @@ class Configuration(dict):
 
         This will also deep merge the values from the mapping
         if they are also dicts.
+
+        This method is transactional: validation errors within the
+        mapping will roll back any partial changes, guaranteeing that
+        the configuration is always in a valid state.
 
         :param mapping: A single mapping to update the configuration with
         :param kwargs: Additional keyword arguments to update the configuration with
@@ -320,90 +601,87 @@ class Configuration(dict):
 
         mappings.append(kwargs.items())
 
-        # Parse and filter mappings
-        for mapping in mappings:
-            for k, v in mapping:
-                if k in self.DEFAULTS:
-                    if isinstance(self[k], dict) and isinstance(v, dict):
-                        # deep merge the dicts
-                        self.deep_update(self[k], v)
-                    else:
-                        self[k] = v
-                else:
-                    self.logger.warning(
-                        "Configuration key %s is not a valid root key, ignoring", k
-                    )
+        # Create a deep copy snapshot of the mutable root sections, so
+        # a failed validation can be rolled back.
+        snapshot = {key: copy.deepcopy(self[key]) for key in self.DEFAULTS}
 
-        # Minimal validation for hosts section
-        # This is not exhaustive, we just wish to avoid a handful of things
-        # in the configuration.
-        hosts = self.get("hosts", [])
-        if isinstance(hosts, list):
-            self._validate_hosts(hosts)
+        try:
+            # Parse and filter mappings
+            for mapping in mappings:
+                for k, v in mapping:
+                    if k in self.DEFAULTS:
+                        if isinstance(self[k], dict) and isinstance(v, dict):
+                            # deep merge the dicts
+                            self.deep_update(self[k], v)
+                        else:
+                            self[k] = v
+                    else:
+                        self.logger.warning(
+                            "Configuration key %s is not a valid root key, ignoring", k
+                        )
+
+            # Perform validation and normalization for the configuration
+            # Since everything routes through this method, it will always
+            # be in charge of raising validation errors.
+            self._validate_and_normalize()
+        except Exception:
+            # Woops, the validation or slicing failed!
+            # Roll back any partial mutation before re-raising
+            self.logger.debug("Rolling back config values due to validation error")
+            for key, value in snapshot.items():
+                self[key] = value
+            raise
 
         return True
 
-    def _validate_hosts(self, hosts: list) -> None:
+    def _validate_and_normalize(self) -> None:
         """
-        Validate the hosts list configuration.
+        Validate and normalize the configuration against the schema.
 
-        :param hosts: List of host configuration dictionaries
-        :raises ValueError: On validation failure
+        This method will run the pydantic schema (:class:`ConfigModel`)
+        over both the ``options`` and ``hosts`` sections of the
+        configuration structure, then write the results back into
+        place.
+
+        Unknown option keys are rejected, unknown host keys are dropped
+        with a warning, and values are coerced to their legit,
+        canonical form (e.g. types fixed, log levels uppercased, etc).
+
+        :raises ValueError: if the configuration fails schema validation
         """
-        # Check for duplicate host names
-        names: list[str] = [
-            str(host.get("name"))
-            for host in hosts
-            if isinstance(host, dict) and "name" in host
-        ]
+        try:
+            model = ConfigModel.model_validate(
+                {"options": self["options"], "hosts": self["hosts"]}
+            )
+        except ValidationError as exc:
+            # Turn the Pydantic ValidationError into an API agnostic
+            # ValueError with a friendly list of problems as message.
+            # I don't love this and optimally we'd raise our own
+            # ConfigurationError type, but that refactor would be
+            # much bigger than I'd like for the time being.
+            hosts = self["hosts"]
+            problems = []
+            for error in exc.errors():
+                loc = list(error["loc"])
 
-        dupes: set[str] = {str(name) for name in names if names.count(name) > 1}
+                # Identify a host by its name rather than its list index.
+                # No one likes counting entries in yaml or toml.
+                if len(loc) >= 2 and loc[0] == "hosts" and isinstance(loc[1], int):
+                    entry = hosts[loc[1]] if loc[1] < len(hosts) else None
+                    if isinstance(entry, dict) and entry.get("name"):
+                        loc[1] = entry["name"]
+                location = ".".join(str(part) for part in loc)
 
-        if dupes:
-            msg = f"Duplicate host names found in configuration: {', '.join(dupes)}"
-            raise ValueError(msg)
+                # Strip pydantic's prefix on custom validators
+                message = error["msg"].removeprefix("Value error, ")
 
-        # Validate each host entry
-        for host in hosts:
-            if not isinstance(host, dict):
-                continue
-
-            # Name field MUST be present
-            if "name" not in host:
-                msg = "Host entry is missing required 'name' field"
-                raise ValueError(msg)
-
-            # IP field MUST be present
-            if "ip" not in host:
-                host_name = host.get("name", "unnamed host")
-                msg = f"Host '{host_name}' is missing required 'ip' field"
-                raise ValueError(msg)
-
-            # IP field cannot contain '@' character
-            # Library will interpret this as a username which will result
-            # in a lot of undefined or unexpected behaviors.
-            # We allow it in the username field, however, for kerberos reasons.
-            if "ip" in host and "@" in str(host["ip"]):
-                host_name = host.get("name", "(unknown)")
-                msg = (
-                    f"Host '{host_name}' has invalid hostname or ip: "
-                    "'@' character is not allowed. "
-                    "If you are trying to specify a username, use the 'username' option."
+                # Top-level (model) errors have no location, just show
+                # the message instead of "(root)" which helps no one.
+                problems.append(
+                    f"  - {location}: {message}" if location else f"  - {message}"
                 )
-                raise ValueError(msg)
 
-    def deep_update(self, d: dict, u: dict) -> dict:
-        """
-        Recursively update a dictionary with another dictionary.
-        Ensures nested dicts are updated rather than replaced.
+            raise ValueError("\n".join(problems)) from exc
 
-        :param d: The dictionary to update
-        :param u: The dictionary with updates
-        :return: The updated dictionary
-        """
-        for k, v in u.items():
-            if isinstance(v, dict) and k in d and isinstance(d[k], dict):
-                self.deep_update(d[k], v)
-            else:
-                d[k] = v
-        return d
+        self["options"] = model.options.model_dump()
+        self["hosts"] = [host.model_dump(exclude_unset=True) for host in model.hosts]

--- a/src/exosphere/inventory.py
+++ b/src/exosphere/inventory.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import re
 from collections.abc import Callable
@@ -259,11 +258,9 @@ class Inventory:
         Attempt to load a host from the cache, or create a new one if that fails
         in any meaningful way.
 
-        Is also responsible for binding the host configuration parameters
-        to the Host object ones, and will log a warning if invalid parameters
-        are found in the configuration dictionary.
-
-        Invalid parameters will be ignored.
+        It will bind the host configuration parameters to the Host
+        objects, which will already have been validated before they
+        reach this point.
 
         The new host's other configuration properties will be updated
         if they have changed from config since (i.e. ip address, port etc)
@@ -275,20 +272,6 @@ class Inventory:
         """
 
         host_obj: Host
-
-        # Validate the host configuration, remove entries that are not
-        # parameters to the Host class constructor with a warning
-        valid_params = {
-            k for k in inspect.signature(Host.__init__).parameters.keys() if k != "self"
-        }
-        for key in list(host_cfg.keys()):
-            if key not in valid_params:
-                self.logger.warning(
-                    "Invalid host configuration option '%s' for host '%s', ignoring.",
-                    key,
-                    name,
-                )
-                del host_cfg[key]
 
         # Return early on cache miss
         if name not in cache:

--- a/src/exosphere/main.py
+++ b/src/exosphere/main.py
@@ -65,22 +65,12 @@ def setup_logging(log_level: str, log_file: str | None = None) -> None:
     # Normalize log level to UPPERCASE
     log_level = log_level.upper()
 
-    # Log message values in case of config clamping
-    clamp_warning: tuple[int, int] | None = None
-
     if log_file:
-        backup_count = app_config["options"]["log_backup_count"]
-        clamped_backup_count = max(1, backup_count)
-
-        # Set log values for deferred warning
-        if clamped_backup_count != backup_count:
-            clamp_warning = (clamped_backup_count, backup_count)
-
         handler = RotatingFileHandler(
             log_file,
             encoding="utf-8",
             maxBytes=app_config["options"]["log_max_bytes"],
-            backupCount=clamped_backup_count,
+            backupCount=app_config["options"]["log_backup_count"],
         )
     else:
         handler = logging.StreamHandler()
@@ -93,15 +83,6 @@ def setup_logging(log_level: str, log_file: str | None = None) -> None:
     )
 
     logging.getLogger("exosphere").setLevel(log_level)
-
-    # We don't raise an exception here, and defer this until now
-    # because this function gets called during the "startup exceptions
-    # are FATAL" phase of initialization, so we just log a warning.
-    if clamp_warning is not None:
-        logging.getLogger(__name__).warning(
-            "log_backup_count must be at least 1! using %d instead of %r",
-            *clamp_warning,
-        )
 
     logging.getLogger(__name__).info("Logging initialized with level: %s", log_level)
 
@@ -243,7 +224,9 @@ def main() -> None:
 
     logger.info("Configuration loaded from: %s", context.confpath)
 
-    # Override configuration options with environment variables, if any
+    # Override configuration options with environment variables, if any.
+    # Environment variables are best effort, invalid values will be
+    # ignored and logged as warnings.
     app_config.from_env()
 
     # initialize logging and setup handlers depending on config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -468,55 +468,6 @@ class TestConfiguration:
         with pytest.raises(TypeError):
             config.update_from_mapping({}, {}, {})
 
-    def test_update_from_mapping_unique_constraints(self):
-        """
-        Ensure that the Configuration object raises a ValueError
-        when duplicate host names are found in the configuration.
-        """
-        config = Configuration()
-
-        with pytest.raises(ValueError, match="Duplicate host names found"):
-            config.update_from_mapping(
-                {
-                    "hosts": [
-                        {"name": "host1", "ip": "127.0.0.4"},
-                        {"name": "host1", "ip": "172.0.0.3"},
-                    ]
-                }
-            )
-
-    @pytest.mark.parametrize(
-        "hosts_data,expected_error_match",
-        [
-            # Missing required fields
-            (
-                [{"ip": "127.0.0.4"}],
-                "missing required 'name' field",
-            ),
-            (
-                [{"name": "host4"}],
-                "missing required 'ip' field",
-            ),
-            # Invalid characters in fields
-            (
-                [{"name": "host1", "ip": "user@127.0.0.1"}],
-                "invalid hostname or ip.*'@' character is not allowed",
-            ),
-        ],
-        ids=["missing_name", "missing_ip", "at_in_ip"],
-    )
-    def test_update_from_mapping_validation_errors(
-        self, hosts_data, expected_error_match
-    ):
-        """
-        Ensure that the configuration object raises appropriate ValueError
-        for various validation failures in the host section.
-        """
-        config = Configuration()
-
-        with pytest.raises(ValueError, match=expected_error_match):
-            config.update_from_mapping({"hosts": hosts_data})
-
     def test_update_from_env(self, mocker, monkeypatch):
         """
         Ensure that the Configuration object can be updated
@@ -554,53 +505,119 @@ class TestConfiguration:
         assert "invalid_key" not in config["options"]
         assert "is not a valid options key" in caplog.text
 
-    def test_update_from_env_nested_dicts(self, mocker, monkeypatch):
+    def test_update_from_env_nested_dicts_ignored(self, monkeypatch, caplog):
         """
-        Ensure that the Configuration object can be updated
-        from environment variables with nested dictionaries using
-        double underscore (__) as a separator.
+        Unknown nested level keys in environment variables are ignored.
+
+        We currently don't make use of these structures in the options
+        schema yet, but they are supported by the Configuration system.
+
+        Env overrides are applied best-effort, so an unknown nested key does
+        not abort: the whole subtree is dropped with a warning, leaving the
+        rest of the configuration valid.
+
+        This should be revisited if we ever add nested dicts to the schema.
         """
         # Mock environment variables for nested dict structure
         monkeypatch.setenv("EXOSPHERE_OPTIONS_NESTED__LEVEL1__KEY1", "value1")
-        monkeypatch.setenv("EXOSPHERE_OPTIONS_NESTED__LEVEL1__KEY2", "42")
-        monkeypatch.setenv("EXOSPHERE_OPTIONS_NESTED__LEVEL2__SUBKEY", "true")
-        monkeypatch.setenv("EXOSPHERE_OPTIONS_DEEP__VERY__NESTED__KEY", "deep_value")
+
+        config = Configuration()
+
+        with caplog.at_level("WARNING"):
+            result = config.from_env()
+
+        assert result is True
+        assert "nested" not in config["options"]
+        assert "nested subtree dropped" in caplog.text
+
+    def test_update_from_env_invalid_value_ignored(self, monkeypatch, caplog):
+        """Bad values from env are ignored, rest of config valid"""
+        monkeypatch.setenv("EXOSPHERE_OPTIONS_MAX_THREADS", "7")  # yes
+        monkeypatch.setenv("EXOSPHERE_OPTIONS_LOG_LEVEL", "BERSERK")  # NO!
+
+        config = Configuration()
+
+        with caplog.at_level("WARNING"):
+            result = config.from_env()
+
+        assert result is True
+        assert config["options"]["max_threads"] == 7
+        assert config["options"]["log_level"] == config.DEFAULTS["options"]["log_level"]
+        assert "Ignoring invalid environment override for 'log_level'" in caplog.text
+
+    def test_update_from_mapping_rolls_back_on_invalid(self):
+        """Failed validation does not leave config partially updated"""
+        config = Configuration()
+        before = copy.deepcopy(dict(config))
+
+        with pytest.raises(ValueError):
+            config.update_from_mapping({"options": {"max_threads": "not a number"}})
+
+        assert dict(config) == before
+
+    def test_update_from_mapping_rolls_back_hosts_on_invalid(self):
+        """A hosts-section validation failure restores the prior hosts list."""
+        config = Configuration()
+        config.update_from_mapping({"hosts": [{"name": "keep", "ip": "10.0.0.1"}]})
+        before = copy.deepcopy(config["hosts"])
+
+        # Duplicate names fail at the ConfigModel level; the prior hosts list
+        # must be left intact rather than replaced by the rejected one.
+        with pytest.raises(ValueError, match="Duplicate host names"):
+            config.update_from_mapping(
+                {"hosts": [{"name": "dup", "ip": "1"}, {"name": "dup", "ip": "2"}]}
+            )
+
+        assert config["hosts"] == before
+
+    def test_from_env_keeps_interdependent_overrides_together(
+        self, monkeypatch, caplog
+    ):
+        """A pair of related overrides are not dropped by an unrelated invalid key"""
+
+        # reap<=lifetime holds for 400<=600, but only if applied together
+        monkeypatch.setenv("EXOSPHERE_OPTIONS_SSH_PIPELINING_REAP_INTERVAL", "400")
+        monkeypatch.setenv("EXOSPHERE_OPTIONS_SSH_PIPELINING_LIFETIME", "600")
+        monkeypatch.setenv("EXOSPHERE_OPTIONS_LOG_LEVEL", "BOGUS")  # the real culprit
+
+        config = Configuration()
+        with caplog.at_level("WARNING"):
+            config.from_env()
+
+        # The boys are still here, gloriously valid together
+        assert config["options"]["ssh_pipelining_reap_interval"] == 400
+        assert config["options"]["ssh_pipelining_lifetime"] == 600
+        # And the paste eating entry isn't
+        assert config["options"]["log_level"] == config.DEFAULTS["options"]["log_level"]
+        assert "log_level" in caplog.text
+
+    def test_from_env_drops_genuine_cross_field_conflict(self, monkeypatch):
+        """
+        Related overrides that are invalid as a pair are dropped wholesale.
+
+        This is a corner case, but in the scenario where two related
+        overrides have a mutual constraint, and they are both present
+        but violate the constraint, we don't apply either of them and
+        drop them as a package deal.
+        """
+
+        # interval >= lifetime, a nonsensical configuration
+        monkeypatch.setenv("EXOSPHERE_OPTIONS_SSH_PIPELINING_REAP_INTERVAL", "900")
+        monkeypatch.setenv("EXOSPHERE_OPTIONS_SSH_PIPELINING_LIFETIME", "500")
 
         config = Configuration()
         result = config.from_env()
 
+        # Did not abort, and both overrides reverted to their defaults
         assert result is True
-
-        # Check nested structure was created correctly
-        assert "nested" in config["options"]
-        assert "level1" in config["options"]["nested"]
-        assert "level2" in config["options"]["nested"]
-        assert config["options"]["nested"]["level1"]["key1"] == "value1"
-        assert config["options"]["nested"]["level1"]["key2"] == 42
-        assert config["options"]["nested"]["level2"]["subkey"] is True
-
-        # Check deeply nested structure
-        assert "deep" in config["options"]
-        assert "very" in config["options"]["deep"]
-        assert "nested" in config["options"]["deep"]["very"]
-        assert config["options"]["deep"]["very"]["nested"]["key"] == "deep_value"
-
-    def test_update_from_env_nested_dicts_custom_parser(self, mocker, monkeypatch):
-        """
-        Ensure that nested dicts work with custom parsers in from_env.
-        """
-
-        # Use a simple parser that just converts to uppercase
-        def uppercase_parser(value):
-            return value.upper()
-
-        monkeypatch.setenv("EXOSPHERE_OPTIONS_CUSTOM__NESTED__VALUE", "lowercase")
-
-        config = Configuration()
-        result = config.from_env(parser=uppercase_parser)
-
-        assert result is True
-        assert config["options"]["custom"]["nested"]["value"] == "LOWERCASE"
+        assert (
+            config["options"]["ssh_pipelining_reap_interval"]
+            == config.DEFAULTS["options"]["ssh_pipelining_reap_interval"]
+        )
+        assert (
+            config["options"]["ssh_pipelining_lifetime"]
+            == config.DEFAULTS["options"]["ssh_pipelining_lifetime"]
+        )
 
     def test_deep_update_simple_merge(self):
         """
@@ -724,47 +741,250 @@ class TestConfiguration:
 
     def test_update_from_mapping_uses_deep_update(self):
         """
-        Ensure that update_from_mapping correctly uses deep_update
-        for nested dictionary structures.
+        Ensure that update_from_mapping merges the option section
+        rather than replace it wholesale.
         """
         config = Configuration()
 
-        # Set up initial state with nested options
-        config["options"]["custom_section"] = {
-            "existing_key": "original",
-            "nested": {"deep_key": "deep_original"},
-        }
+        # First update sets one option
+        config.update_from_mapping({"options": {"log_level": "DEBUG"}})
+        # Second update sets a different option
+        config.update_from_mapping({"options": {"max_threads": 42}})
 
-        # Update with overlapping nested structure
-        mapping = {
-            "options": {
-                "log_level": "DEBUG",  # Update existing top-level key
-                "custom_section": {
-                    "existing_key": "updated",  # Update existing nested key
-                    "new_key": "added",  # Add new nested key
-                    "nested": {
-                        "deep_key": "deep_updated",  # Update deep nested key
-                        "deep_new": "deep_added",  # Add new deep nested key
-                    },
-                },
-            }
-        }
-
-        result = config.update_from_mapping(mapping)
-        assert result is True
-
-        # Check that deep_update was used (values were merged, not replaced)
+        # Both updates survive (deep merge, not replacement)
         assert config["options"]["log_level"] == "DEBUG"
-        assert config["options"]["custom_section"]["existing_key"] == "updated"
-        assert config["options"]["custom_section"]["new_key"] == "added"
-        assert (
-            config["options"]["custom_section"]["nested"]["deep_key"] == "deep_updated"
-        )
-        assert config["options"]["custom_section"]["nested"]["deep_new"] == "deep_added"
+        assert config["options"]["max_threads"] == 42
 
-        # Ensure other default options are still present
-        assert "debug" in config["options"]
+        # Ensure other default options are still present and untouched
+        assert config["options"]["debug"] is False
         assert "cache_file" in config["options"]
+
+
+class TestSchemaValidation:
+    """Test suite for config schema validation and related behaviors."""
+
+    def test_host_model_mirrors_host_constructor(self):
+        """
+        HostModel must match the Host object constructor at all times
+
+        Most of our instantiation code simply dumps it wholesale into the
+        Host constructor as kwargs, so they should not drift.
+        """
+        import inspect
+
+        from exosphere.config import HostModel
+        from exosphere.objects import Host
+
+        ctor_params = {
+            name
+            for name in inspect.signature(Host.__init__).parameters
+            if name != "self"
+        }
+
+        assert set(HostModel.model_fields) == ctor_params
+
+    def test_defaults_derived_from_options_model(self):
+        """Class option defaults are the canonical dump of OptionsModel."""
+        from exosphere.config import OptionsModel
+
+        assert Configuration.DEFAULTS["options"] == OptionsModel().model_dump()
+
+    def test_unknown_option_is_rejected(self):
+        """Unknown option keys hard fail with a ValueError"""
+        config = Configuration()
+
+        with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+            config.update_from_mapping({"options": {"max_trheads": 4}})
+
+    def test_deprecated_option_is_dropped_with_warning(self, mocker, caplog):
+        """Deprecated options are tolerated but dropped"""
+        from exosphere.config import OptionsModel
+
+        mocker.patch.dict(
+            OptionsModel.DEPRECATED_OPTIONS,
+            {"legacy_option": "removed in 4.2.0; use modern_option instead"},
+        )
+
+        config = Configuration()
+
+        with caplog.at_level("WARNING"):
+            result = config.update_from_mapping({"options": {"legacy_option": 123}})
+
+        assert result is True
+        # The deprecated key is dropped, not retained
+        assert "legacy_option" not in config["options"]
+        # And a warning naming it (and the migration note) is logged
+        assert "legacy_option" in caplog.text
+        assert "removed in 4.2.0; use modern_option instead" in caplog.text
+
+    @pytest.mark.parametrize("backup_count", [0, -5])
+    def test_log_backup_count_below_one_rejected(self, backup_count):
+        """
+        Log backup count must be >=1
+        Otherwise, the rotating file handler will just disable rotation
+        entirely, which is surprising, and counterproductive.
+        """
+        config = Configuration()
+
+        with pytest.raises(ValueError, match="greater than or equal to 1"):
+            config.update_from_mapping({"options": {"log_backup_count": backup_count}})
+
+    @pytest.mark.parametrize(
+        "mapping",
+        [
+            {"hosts": [{"name": "", "ip": "127.0.0.1"}]},
+            {"hosts": [{"name": "   ", "ip": "127.0.0.1"}]},
+            {"hosts": [{"name": "a", "ip": ""}]},
+            {"hosts": [{"name": "a", "ip": "127.0.0.1", "username": ""}]},
+            {"options": {"default_username": ""}},
+            {"options": {"editor": ""}},
+        ],
+        ids=["name", "name_ws", "ip", "host_user", "default_user", "editor"],
+    )
+    def test_empty_string_fields_rejected(self, mapping):
+        """
+        Identifier/credential string fields reject empty or whitespace-only
+        values rather than silently accepting them.
+        """
+        config = Configuration()
+
+        with pytest.raises(ValueError, match="should have at least 1 character"):
+            config.update_from_mapping(mapping)
+
+    def test_identifier_whitespace_is_stripped(self):
+        """Surrounding whitespace on name/ip is normalized away."""
+        config = Configuration()
+
+        config.update_from_mapping(
+            {"hosts": [{"name": "  web1  ", "ip": "  10.0.0.1  "}]}
+        )
+
+        assert config["hosts"][0] == {"name": "web1", "ip": "10.0.0.1"}
+
+    def test_duplicate_host_names_rejected(self):
+        """Duplicate host names are rejected: the inventory requires unique names."""
+        config = Configuration()
+
+        with pytest.raises(ValueError, match="Duplicate host names found"):
+            config.update_from_mapping(
+                {
+                    "hosts": [
+                        {"name": "host1", "ip": "127.0.0.4"},
+                        {"name": "host1", "ip": "172.0.0.3"},
+                    ]
+                }
+            )
+
+    @pytest.mark.parametrize(
+        "hosts_data,expected_error_match",
+        [
+            # Missing name: no name to show, so the list index is used
+            (
+                [{"ip": "127.0.0.4"}],
+                r"hosts\.0\.name: Field required",
+            ),
+            # Missing ip: the host is identified by its name, not its index
+            (
+                [{"name": "host4"}],
+                r"hosts\.host4\.ip: Field required",
+            ),
+            # Invalid characters in fields
+            (
+                [{"name": "host1", "ip": "user@127.0.0.1"}],
+                "'@' character is not allowed in hostname or ip",
+            ),
+        ],
+        ids=["missing_name", "missing_ip", "at_in_ip"],
+    )
+    def test_host_field_validation_errors(self, hosts_data, expected_error_match):
+        """
+        Host entries raise an appropriate ValueError for missing required
+        fields and for an '@' in the ip field.
+        """
+        config = Configuration()
+
+        with pytest.raises(ValueError, match=expected_error_match):
+            config.update_from_mapping({"hosts": hosts_data})
+
+    def test_host_error_identifies_host_by_name(self):
+        """
+        A field error on one host among many is located by the host's name,
+        not its list index, so operators can find it without counting entries.
+        """
+        config = Configuration()
+
+        with pytest.raises(ValueError, match=r"hosts\.web3\.ip: Field required"):
+            config.update_from_mapping(
+                {
+                    "hosts": [
+                        {"name": "web1", "ip": "10.0.0.1"},
+                        {"name": "web2", "ip": "10.0.0.2"},
+                        {"name": "web3"},  # missing ip, third in the list
+                    ]
+                }
+            )
+
+    @pytest.mark.parametrize("port", [0, 65536])
+    def test_host_port_out_of_range_rejected(self, port):
+        """Port must be within 1-65535."""
+        config = Configuration()
+
+        with pytest.raises(ValueError, match="hosts.a.port"):
+            config.update_from_mapping(
+                {"hosts": [{"name": "a", "ip": "h", "port": port}]}
+            )
+
+    @pytest.mark.parametrize("port", [1, 65535])
+    def test_host_port_boundaries_accepted(self, port):
+        """The 1 and 65535 boundaries are valid ports."""
+        config = Configuration()
+
+        config.update_from_mapping({"hosts": [{"name": "a", "ip": "h", "port": port}]})
+
+        assert config["hosts"][0]["port"] == port
+
+    @pytest.mark.parametrize(
+        "given,expected",
+        [("NOPASSWD", "nopasswd"), ("Skip", "skip"), ("SKIP", "skip")],
+    )
+    def test_sudo_policy_normalized_case_insensitively(self, given, expected):
+        """Sudo policies are accepted in any case and stored lowercased."""
+        config = Configuration()
+
+        config.update_from_mapping(
+            {
+                "options": {"default_sudo_policy": given},
+                "hosts": [{"name": "a", "ip": "h", "sudo_policy": given}],
+            }
+        )
+
+        assert config["options"]["default_sudo_policy"] == expected
+        assert config["hosts"][0]["sudo_policy"] == expected
+
+    def test_unknown_host_key_dropped_with_warning(self, caplog):
+        """
+        Unknown keys in a host entry are dropped with a warning
+        We don't hard fail to be reasonably forward compatible, and
+        we should be more forgiving towards big inventories.
+        """
+        config = Configuration()
+
+        with caplog.at_level("WARNING"):
+            result = config.update_from_mapping(
+                {"hosts": [{"name": "host1", "ip": "127.0.0.1", "wrong_key": "oops"}]}
+            )
+
+        assert result is True
+        # Unknown key is dropped from the normalized host entry
+        assert "typo" not in config["hosts"][0]
+        assert config["hosts"][0] == {"name": "host1", "ip": "127.0.0.1"}
+        # And a warning is logged naming the offending key and host
+        # Long enough have we stood by and watched ourselves not
+        # include WHAT generated the error as part of the error.
+        assert (
+            "Unknown host configuration option 'wrong_key' for host 'host1'"
+            in caplog.text
+        )
 
 
 class TestKnownLoaders:
@@ -807,7 +1027,7 @@ class TestValidate:
         target = tmp_path / "config.yaml"
         target.write_text("hosts:\n  - name: a\n")  # missing 'ip'
 
-        with pytest.raises(ValueError, match="missing required 'ip' field"):
+        with pytest.raises(ValueError):
             config_module.validate(target)
 
     def test_malformed_file_raises(self, tmp_path):
@@ -819,6 +1039,8 @@ class TestValidate:
 
     def test_non_mapping_raises(self, tmp_path):
         """A top-level non-mapping config reports the real problem clearly."""
+        # This test is yaml-specific but it is the easiest way
+        # to express this mistake in the context of the test
         target = tmp_path / "config.yaml"
         target.write_text("- a\n- b\n")  # a list, not a mapping
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -451,41 +451,6 @@ class TestInventory:
         assert result.supported is True
         assert result.online is True
 
-    def test_load_or_create_host_with_unknown_option(
-        self, mocker, mock_diskcache, caplog
-    ):
-        """
-        Test that load_or_create_host ignores unknown options in host configuration.
-        """
-        from exosphere.objects import Host
-
-        inventory = Inventory(Configuration())
-        cache_mock = mock_diskcache.return_value.__enter__.return_value
-        cache_mock.__contains__.return_value = False
-
-        host_cfg = {
-            "name": "host5",
-            "ip": "127.0.0.8",
-            "port": 22,
-            "unknown_option": "should_be_ignored",
-        }
-        with caplog.at_level("WARNING"):
-            result = inventory.load_or_create_host("host5", host_cfg, cache_mock)
-
-        # Ensure the host is created without the unknown option
-        assert isinstance(result, Host)
-        assert result.name == "host5"
-        assert result.ip == "127.0.0.8"
-        assert result.port == 22
-        assert not hasattr(result, "unknown_option")
-
-        # Ensure the warning is logged
-        assert any(
-            "Invalid host configuration option 'unknown_option' for host 'host5', ignoring."
-            in message
-            for message in caplog.messages
-        )
-
     def test_load_or_create_host_with_minimal_state(self, mocker, mock_diskcache):
         """
         Test that a HostState with all None values can be loaded.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -453,41 +453,6 @@ class TestMain:
         assert handler.backupCount == 7
         handler.close()
 
-    @pytest.mark.parametrize("backup_count", [0, -5])
-    def test_setup_logging_clamps_backup_count(
-        self, mocker, tmp_path, caplog, backup_count
-    ):
-        """
-        Invalid integer values for backup count are clamped to 1
-        """
-        from logging.handlers import RotatingFileHandler
-
-        basic_config = mocker.patch("logging.basicConfig")
-        mocker.patch.object(logging.getLogger("exosphere"), "setLevel")
-        log_file = tmp_path / "test.log"
-
-        from exosphere import Configuration
-
-        config = Configuration()
-        config.update_from_mapping(
-            {"options": {"log_max_bytes": 1234, "log_backup_count": backup_count}}
-        )
-        mocker.patch("exosphere.main.app_config", config)
-
-        caplog.set_level(logging.WARNING, logger="exosphere.main")
-
-        from exosphere.main import setup_logging
-
-        setup_logging("DEBUG", str(log_file))
-
-        handler = basic_config.call_args.kwargs["handlers"][0]
-        assert isinstance(handler, RotatingFileHandler)
-        assert handler.backupCount == 1
-        handler.close()
-
-        # Check that we log a warning
-        assert "log_backup_count must be at least 1" in caplog.text
-
     def test_setup_logging_invalid_log_level(self):
         """
         Test setup_logging with an invalid log level.

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -538,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev11"
+version = "3.0.0.dev12"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },
@@ -548,6 +557,7 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "prompt-toolkit" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "textual" },
@@ -589,6 +599,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=24.0" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
+    { name = "pydantic", specifier = ">=2.12" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=14.1.0" },
     { name = "textual", specifier = ">=6.7.0" },
@@ -1206,6 +1217,77 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
 ]
 
 [[package]]
@@ -1877,6 +1959,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pulls in Pydantic to define and validate the configuration schema.

Previously, we had all sorts of validation done at call sites, which was enough for our purposes, but it is starting to chafe, given the nonsensical "let's silently clamp this value" garbage the previous log rotation option code was doing.

Configuration errors are now universally caught at load time instead of whenever at runtime, which is nicer.

We now have a nice pydantic model for:

- The Options schema (global config options)
- The Inventory schema (per-host config options)
- The Configuration schema (Entire structure, composed)

I have moved most (all?) option validation at load/validation time instead of wherever it was (there wasn't a lot, it was mostly around load_or_create_host and init stuff in main(), really).

The usage API and contract doesn't really change for Configuration, it still raises ValueError on invalid things -- it just happens to be WAY stricter about it than before.

The DEFAULTS class level dict is still available and still the expected way to read default values for options at runtime, only it is now generated from the Pydantic model schema.

The authoritative spot for values, defaults and their validation is now the pydantic models in the config module.

Additionally, the Configuration dict has been made transactionally atomic, so that any partial updates to configuration keys via update_from_mapping (or one of its wrappers) will be rolled back if the validation of the batch given to it fails. This is a nice, low cost improvement that makes the configuration state more predictable internally.

Behavior changes from previous implementation:

- the Options section is now way more strict about what it accepts and will raise ValueError on unknown/invalid keys
- The Hosts (inventory) section is as permissive as it was before, still emits a warning on unknown keys, but drops them entirely from the resulting structure (preferable)
- The stupid, awful, silent clamp behavior for log rotation backup count now has a sane validator, and will raise a ValueError instead of silently correcting a value changed without reading the docs.
- Some validation is stricter: Fields expecting integer values now enforce a minimum value, and nonsensical values between multiple related fields (lifetime min vs max etc) will also raise ValueError instead of doing whatever at runtime
- Similarly, string values that are mandatory now have a minimum length of 1 and WILL trim whitespace automatically.
- Specifically:
  - ssh_pipelining_reap_interval can't exceed ssh_pipelining_lifetime and they both must be >= 1.
  - log_backup_count must be >= 1
- Options provided through Environment Variables are now validated in the same way as all other configuration methods -- they were not previously, which was an oversight.
- Invalid environment variables are processed on a best effort basis:
    - Invalid keys are ignored, dropped and logged as warning
    - nested dict keys will have their entire subtree dropped if any of the leaves are invalid. The logged message will indicate this.
    - Keys that have a mutual constraint violation will be dropped together instead of only applying one of them.

All of the original config constraints are still present, behave the exact same, but are now enforced by the model validation instead of a flaky decision tree hidden in update_from_mapping.

I've also pre-emptively added a special list for deprecated/removed global options that makes them _tolerated_ in the schema, with a warning that would emit what to do use instead (it was low effort).

This should address the general spirit of issue #311