### PR TITLE
Core: Enforce locale and shell for remote commands

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -167,6 +167,7 @@ These options are applied globally, and affect how Exosphere behaves at runtime.
 - :option:`stale_threshold`
 - :option:`default_timeout`
 - :option:`default_username`
+- :option:`default_ssh_locale`
 - :option:`max_threads`
 - :option:`ssh_pipelining`
 - :option:`ssh_pipelining_lifetime`
@@ -829,6 +830,60 @@ and examples of how to set them in the configuration file.
                     }
                 }
 
+.. _default_ssh_locale_option:
+
+.. option:: default_ssh_locale
+
+    The locale forced on every command Exosphere runs on a remote host.
+
+    Some exosphere providers have to rely on parsing the human-readable output
+    of remote commands to determine the state of the host.
+
+    Since many of these commands are subject to gettext translation, which
+    changes on the remote host depending on the locale, this can lead to
+    non-deterministic results.
+
+    In order to prevent this scenario, Exosphere, by default, forces the locale
+    on the remote host to ``C`` (POSIX locale), which is guaranteed to be available
+    and will always produce canonical, untranslated output.
+
+    A reasonable alternative, if available, is ``C.UTF-8``.
+
+    .. attention::
+        Unless you have a very specific reason to do so, we do not recommend
+        changing this value from the default, as it may break functionality in
+        some providers.
+
+    **Default**: ``C``
+
+    **Example**:
+
+    .. tabs::
+
+        .. group-tab:: YAML
+
+            .. code-block:: yaml
+
+                options:
+                  default_ssh_locale: C.UTF-8
+
+        .. group-tab:: TOML
+
+            .. code-block:: toml
+
+                [options]
+                default_ssh_locale = "C.UTF-8"
+
+        .. group-tab:: JSON
+
+            .. code-block:: json
+
+                {
+                    "options": {
+                        "default_ssh_locale": "C.UTF-8"
+                    }
+                }
+
 .. _max_threads_option:
 
 .. option:: max_threads
@@ -1294,6 +1349,7 @@ has a custom connection timeout value set, overriding :option:`default_timeout`.
 - :option:`description`: A short string describing the host, to be displayed in UIs
 - :option:`connect_timeout`: The number of seconds to wait for a response from the host over SSH
 - :option:`sudo_policy`: The sudo policy to use when running commands on the host
+- :option:`ssh_locale`: The locale forced on remote commands run against the host
 
 Below is the detailed list of all available host options and their defaults.
 
@@ -1628,6 +1684,63 @@ Below is the detailed list of all available host options and their defaults.
                             "name": "myhost",
                             "ip": "myhost.example.com",
                             "sudo_policy": "nopasswd"
+                        }
+                    ]
+                }
+
+.. _hosts_ssh_locale_option:
+
+.. option:: ssh_locale
+
+    The locale forced on remote commands run against this host.
+
+    .. admonition:: Note
+
+        This option has precedence over the global option,
+        see :option:`default_ssh_locale` for documentation and
+        usage detail.
+
+    .. attention::
+
+        Unless you have a very specific reason to do so, we do not recommend
+        changing this value from the default, as it may break functionality in
+        some providers.
+
+
+    **Default**: Value of :option:`default_ssh_locale`
+
+    **Example**:
+
+    .. tabs::
+
+        .. group-tab:: YAML
+
+            .. code-block:: yaml
+
+                hosts:
+                  - name: myhost
+                    ip: myhost.example.com
+                    ssh_locale: C.UTF-8
+
+        .. group-tab:: TOML
+
+            .. code-block:: toml
+
+                [[hosts]]
+                name = "myhost"
+                ip = "myhost.example.com"
+                ssh_locale = "C.UTF-8"
+
+        .. group-tab:: JSON
+
+            .. code-block:: json
+
+                {
+                    "hosts": [
+                        {
+                            "name": "myhost",
+                            "ip": "myhost.example.com",
+                            "ssh_locale": "C.UTF-8"
                         }
                     ]
                 }

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -27,6 +27,7 @@ hostname
 init
 installonly
 ip
+janky
 jinja
 jinja2
 json

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -83,7 +83,14 @@ entirely through SSH connections and standard system utilities.
 
 - **SSH access** to the remote host (with an SSH `agent`_ for authentication)
 - **Package manager binaries** installed and available in ``$PATH`` (typically pre-installed)
-- **Standard UNIX utilities** such as ``grep``, ``awk``, and ``cut`` (universally available)
+- **A POSIX Shell** [#binsh]_ (present on every supported platform)
+- **Standard UNIX utilities** such as ``grep``, ``awk``, and ``cut`` (POSIX-compliant, typically available by default)
+
+.. [#binsh]
+    Exosphere runs all remote queries through the POSIX standard ``/bin/sh``
+    shell, which is present on all supported platforms, ensuring consistent
+    behavior across them.
+
 
 **Optional Requirements**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev15"
+version = "3.0.0.dev16"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/config.py
+++ b/src/exosphere/config.py
@@ -53,6 +53,11 @@ SudoPolicyName = Annotated[str, AfterValidator(_normalize_sudo_policy)]
 # Reusable string type for fields where an empty value is always a mistake
 NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
+# Reusable string type for a locale name (e.g. "C", "C.UTF-8", "en_US.UTF-8").
+LocaleName = Annotated[
+    str, StringConstraints(strip_whitespace=True, pattern=r"^[A-Za-z0-9._@-]+$")
+]
+
 
 class OptionsModel(BaseModel):
     """
@@ -109,6 +114,7 @@ class OptionsModel(BaseModel):
     )
     default_username: NonEmptyStr | None = None  # Default global SSH username
     default_sudo_policy: SudoPolicyName = "skip"  # Global sudo policy for pkg ops
+    default_ssh_locale: LocaleName = "C"  # Locale forced on remote commands
     max_threads: int = Field(default=15, ge=1)  # Max threads for parallel ops
     ssh_pipelining: bool = False  # Enable SSH pipelining for SSH connections
     ssh_pipelining_lifetime: int = Field(  # Max lifetime (secs) of SSH connections
@@ -176,6 +182,7 @@ class HostModel(BaseModel):
     description: str | None = None
     connect_timeout: int | None = Field(default=None, ge=1)
     sudo_policy: SudoPolicyName | None = None
+    ssh_locale: LocaleName | None = None
 
     @model_validator(mode="before")
     @classmethod

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -5,7 +5,7 @@ from enum import Enum
 from threading import RLock
 from typing import TypeAlias
 
-from fabric import Connection
+from fabric import Config, Connection
 from paramiko.ssh_exception import PasswordRequiredException
 
 from exosphere import app_config
@@ -18,6 +18,7 @@ from exosphere.errors import (
 )
 from exosphere.providers import PkgManagerFactory
 from exosphere.providers.api import PkgManager
+from exosphere.runners import ExosphereRemote
 from exosphere.security import SudoPolicy, check_sudo_policy
 from exosphere.setup import detect
 
@@ -84,6 +85,7 @@ class Host:
         description: str | None = None,
         connect_timeout: int | None = None,
         sudo_policy: str | None = None,
+        ssh_locale: str | None = None,
     ) -> None:
         """
         Create a new Host Object
@@ -95,8 +97,6 @@ class Host:
         Keep in mind the need to verify this process if you make
         changes to the constructor signature or default values.
 
-        Intended to be serializable!
-
         :param name: Name of the host
         :param ip: IP address or FQDN of the host
         :param port: Port number for SSH connection (default is 22)
@@ -104,6 +104,7 @@ class Host:
         :param description: Optional description for the host
         :param connect_timeout: Connection timeout in seconds (optional)
         :param sudo_policy: Sudo policy for package manager operations (skip, nopasswd)
+        :param ssh_locale: Locale forced on remote commands (optional, default is C)
         """
         # Setup logging
         self.logger = logging.getLogger(__name__)
@@ -135,6 +136,11 @@ class Host:
         # Sudo Policy for package manager operations
         target_policy: str = sudo_policy or app_config["options"]["default_sudo_policy"]
         self.sudo_policy: SudoPolicy = SudoPolicy(target_policy.lower())
+
+        # Locale forced on remote commands.
+        # Some providers scrape human-readable output, and gettext
+        # localization must remain consistent for that to work.
+        self.ssh_locale: str = ssh_locale or app_config["options"]["default_ssh_locale"]
 
         # online status, defaults to False
         # until first discovery.
@@ -274,6 +280,15 @@ class Host:
 
         Connection objects are recycled if already created.
 
+        The connection is setup with an environment override that
+        forces two things on all commands run through it:
+
+        1. The locale is set to the configured value (default is C)
+        2. The command is explicitly ran under /bin/sh (POSIX)
+
+        This allows consistent, deterministic output and behavior,
+        regardless of the user's login shell or locale.
+
         If you work with Host objects directly, make sure to call
         `host.close()` when done with operations (such as discover,
         refresh_updates, etc) to avoid leaving ssh connections open.
@@ -291,6 +306,14 @@ class Host:
                     "host": self.ip,
                     "port": self.port,
                     "connect_timeout": self.connect_timeout,
+                    # Use Exosphere runner and locale config to ensure
+                    # a normalized execution environment
+                    "config": Config(
+                        overrides={
+                            "runners": {"remote": ExosphereRemote},
+                            "exosphere_locale": self.ssh_locale,
+                        }
+                    ),
                 }
 
                 # Determine which username to use for the connection.

--- a/src/exosphere/runners.py
+++ b/src/exosphere/runners.py
@@ -1,0 +1,67 @@
+"""
+SSH Transport Runners module for Exosphere.
+
+Fabric Runners and related middleware are implemented within this
+module, and the Connection object provided by objects.Host is intended
+to make use of them.
+"""
+
+import shlex
+
+from fabric.runners import Remote
+
+
+class ExosphereRemote(Remote):
+    """
+    Fabric Remote runner used by Exosphere for all remote commands.
+
+    The custom runner, intended to be inserted in Fabric Connection
+    objects, performs two modifications to the behavior of the default
+    Fabric Remote runner:
+
+    1. It wraps every command in ``/bin/sh -c``, so that commands are
+       always interpreted by a POSIX shell, independent of platform or
+       login shell
+
+    2. It exports a deterministic locale (both ``LC_ALL`` and ``LANG``)
+       to ensure consistent human-readable output from remote package
+       managers and other tools that may be localized via gettext on
+       non-english systems.
+
+    The choice of ``/bin/sh`` is deliberate: it is guaranteed to be
+    present by POSIX on every single one of our supported platforms.
+
+    C as a locale, also defaults to English, essentially, making
+    the inevitable scraping in some providers deterministic.
+
+    In both cases, these changes serve to transparently normalize the
+    remote environment, regardless of user configuration, without
+    requiring any changes. If someone, for some ineffable reason,
+    has configured the login shell for their remote user to be tcsh
+    or fish, on a German localized system, everything will still work
+    exactly as expected.
+
+    Sudo commands do not change behavior in regard to SUDOERS_COMMANDS
+    allowlist matching, since the sudo binary will be called from the
+    inner ``/bin/sh`` shell, and will inherit the locale as long as the
+    sudoers configuration allows it (default configuration does).
+
+    If the internal ExosphereRemote locale is not set, it defaults to C.
+    """
+
+    # Locale used when the runner context does not carry one. This
+    # should not happen in normal operation, but keeps derived
+    # connections safe and predictable.
+    DEFAULT_LOCALE: str = "C"
+
+    def send_start_message(self, command: str) -> None:
+        """
+        Wrap the command in a POSIX ``/bin/sh`` invocation that exports the
+        configured locale, then hand it off to the channel.
+
+        :param command: The command Fabric will execute remotely.
+        """
+        locale = getattr(self.context, "exosphere_locale", self.DEFAULT_LOCALE)
+        payload = f"export LC_ALL={locale} LANG={locale} && {command}"
+
+        super().send_start_message("/bin/sh -c " + shlex.quote(payload))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -851,6 +851,38 @@ class TestSchemaValidation:
         with pytest.raises(ValueError, match="should have at least 1 character"):
             config.update_from_mapping(mapping)
 
+    @pytest.mark.parametrize(
+        "bad_locale",
+        ["C; rm -rf /", "en_US.UTF-8 extra", "C && evil", "$(evil)", "C|x"],
+        ids=["semicolon", "space", "and", "subshell", "pipe"],
+    )
+    def test_ssh_locale_rejects_shell_unsafe_values(self, bad_locale):
+        """
+        Locale options are exported verbatim into a remote shell command, so
+        values with shell metacharacters or whitespace are rejected outright.
+        """
+        config = Configuration()
+
+        with pytest.raises(ValueError, match="should match pattern"):
+            config.update_from_mapping({"options": {"default_ssh_locale": bad_locale}})
+
+        with pytest.raises(ValueError, match="should match pattern"):
+            config.update_from_mapping(
+                {"hosts": [{"name": "a", "ip": "h", "ssh_locale": bad_locale}]}
+            )
+
+    @pytest.mark.parametrize(
+        "good_locale",
+        ["C", "POSIX", "C.UTF-8", "en_US.UTF-8", "de_DE.UTF-8@euro", "  C.UTF-8  "],
+    )
+    def test_ssh_locale_accepts_valid_values(self, good_locale):
+        """Valid locale names are accepted, with surrounding whitespace stripped."""
+        config = Configuration()
+
+        config.update_from_mapping({"options": {"default_ssh_locale": good_locale}})
+
+        assert config["options"]["default_ssh_locale"] == good_locale.strip()
+
     def test_identifier_whitespace_is_stripped(self):
         """Surrounding whitespace on name/ip is normalized away."""
         config = Configuration()

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -7,6 +7,7 @@ from exosphere.data import HostInfo, Update
 from exosphere.errors import DataRefreshError, OfflineHostError
 from exosphere.objects import Host, HostOperation
 from exosphere.providers.api import requires_sudo
+from exosphere.runners import ExosphereRemote
 from exosphere.security import SudoPolicy
 
 
@@ -204,6 +205,7 @@ class TestHostObject:
             port=host.port,
             user=host.username,
             connect_timeout=host.connect_timeout,
+            config=mocker.ANY,
         )
 
     def test_host_connection_defaults(self, mocker, mock_connection):
@@ -222,6 +224,7 @@ class TestHostObject:
             host=host.ip,
             port=22,  # Default port
             connect_timeout=10,  # Default connect timeout
+            config=mocker.ANY,
         )
 
     def test_host_connection_global_username(
@@ -242,6 +245,7 @@ class TestHostObject:
             port=22,  # Default port
             user="test_user",  # Global username from config
             connect_timeout=10,  # Default connect timeout
+            config=mocker.ANY,
         )
 
     def test_host_connection_username_overrides_global(
@@ -263,7 +267,33 @@ class TestHostObject:
             port=22,  # Default port
             user="specific_user",  # Specific username overrides global
             connect_timeout=10,  # Default connect timeout
+            config=mocker.ANY,
         )
+
+    def test_host_connection_locale_default(self, mocker, mock_connection):
+        """
+        The connection uses the ExosphereRemote runner and carries the default
+        locale (C) for it via connection config.
+        """
+        host = Host(name="test_host", ip="127.0.0.8")
+
+        _ = host.connection
+
+        config = mock_connection.call_args.kwargs["config"]
+        assert config.runners.remote is ExosphereRemote
+        assert config.exosphere_locale == "C"
+
+    def test_host_connection_locale_override(self, mocker, mock_connection):
+        """
+        A per-host ssh_locale overrides the global default and is carried to
+        the connection config for the runner to apply.
+        """
+        host = Host(name="test_host", ip="127.0.0.8", ssh_locale="C.UTF-8")
+
+        _ = host.connection
+
+        config = mock_connection.call_args.kwargs["config"]
+        assert config.exosphere_locale == "C.UTF-8"
 
     def test_host_config_sudo_policy(self, mocker):
         """
@@ -390,7 +420,10 @@ class TestHostObject:
 
         # Ensure the connection was established
         mock_connection.assert_called_once_with(
-            host=host.ip, port=host.port, connect_timeout=host.connect_timeout
+            host=host.ip,
+            port=host.port,
+            connect_timeout=host.connect_timeout,
+            config=mocker.ANY,
         )
 
     def test_host_discovery_offline(self, mocker, mock_connection):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1,0 +1,100 @@
+import shlex
+
+from fabric import Config, Connection
+
+from exosphere.runners import ExosphereRemote
+
+
+class TestExosphereRemote:
+    """
+    Tests for the ExosphereRemote Fabric runner.
+    """
+
+    def _make_runner(self, mocker, context):
+        runner = ExosphereRemote(context=context)
+        runner.channel = mocker.Mock()
+        return runner
+
+    def _sent_payload(self, runner) -> str:
+        sent = runner.channel.exec_command.call_args.args[0]
+        assert sent.startswith("/bin/sh -c ")
+        return shlex.split(sent)[2]
+
+    def test_wraps_command_in_posix_sh_with_locale(self, mocker):
+        """The command is wrapped and the locale exported ahead of it."""
+        context = mocker.Mock()
+        context.exosphere_locale = "C.UTF-8"
+        runner = self._make_runner(mocker, context)
+
+        runner.send_start_message("dnf check-update | grep '^Inst'")
+
+        assert self._sent_payload(runner) == (
+            "export LC_ALL=C.UTF-8 LANG=C.UTF-8 && dnf check-update | grep '^Inst'"
+        )
+
+    def test_privileged_command_reaches_sudo_verbatim(self, mocker):
+        """
+        For a sudo invocation, the command sudo receives (after the wrap) is
+        the verbatim privileged command, preserving sudoers matching.
+
+        The message is built on what Fabric does in source.
+        """
+        context = mocker.Mock()
+        context.exosphere_locale = "C"
+        runner = self._make_runner(mocker, context)
+
+        runner.send_start_message("sudo -S -p '[sudo] password: ' -- pkg update -q")
+
+        assert self._sent_payload(runner) == (
+            "export LC_ALL=C LANG=C && sudo -S -p '[sudo] password: ' -- pkg update -q"
+        )
+
+    def test_defaults_to_C_when_locale_absent(self, mocker):
+        """A connection without exosphere_locale falls back to the C locale."""
+        context = mocker.Mock(spec=[])  # no exosphere_locale attribute
+        runner = self._make_runner(mocker, context)
+
+        runner.send_start_message("uname -s")
+
+        assert self._sent_payload(runner) == "export LC_ALL=C LANG=C && uname -s"
+
+    def test_reads_locale_from_real_connection_config(self, mocker):
+        """
+        The locale carried in a real Fabric Connection's config (the way
+        Host.connection sets it) reaches the wrapped payload.
+
+        This drives a real Connection rather than a Mock, exercising invoke's
+        config proxying that the Host unit tests stub out.
+        """
+        cx = Connection(
+            "localhost",
+            config=Config(overrides={"exosphere_locale": "C.UTF-8"}),
+        )
+        runner = self._make_runner(mocker, cx)
+
+        runner.send_start_message("uname -s")
+
+        assert self._sent_payload(runner) == (
+            "export LC_ALL=C.UTF-8 LANG=C.UTF-8 && uname -s"
+        )
+
+    def test_payload_is_shlex_quoted_as_single_argument(self, mocker):
+        """
+        The wrapped payload is handed to ``/bin/sh -c`` as a single
+        shell-quoted argument, so shell metacharacters in the command never
+        escape the quoting.
+        """
+        context = mocker.Mock()
+        context.exosphere_locale = "C"
+        runner = self._make_runner(mocker, context)
+
+        nasty = "echo $(id) && rm -rf / ; `whoami` | tee 'x'"
+        runner.send_start_message(nasty)
+
+        sent = runner.channel.exec_command.call_args.args[0]
+        tokens = shlex.split(sent)
+
+        # None of our nasty metacharacters have escaped to more tokens
+        assert len(tokens) == 3
+        assert tokens[:2] == ["/bin/sh", "-c"]
+        assert tokens[2] == f"export LC_ALL=C LANG=C && {nasty}"

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev15"
+version = "3.0.0.dev16"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
We now systematically enforce the POSIX /bin/sh shell as well as the C locale (by default) for all remote commands ran through the Fabric connection object within Exosphere.

This change implements and formalizes a previously implicit assumption about remote shell and environment requirements, and ensures that Exosphere always performs operations in a normalized environment.

This ensures two things:

* The remote shell is always POSIX compliant, which can be relied on as a very modest baseline for Provider implementations
* The remote locale is always C, which ensures that all messages and output from remote commands are going to be deterministic, instead of potentially localized.

The goal is to ensure we get our nice deterministic environment, without having to care about the remote user's login shell or locale, or adding firm user-facing requirements that require users to change their setup.

This boils down the requirements for Exosphere on that front to: "OS must be POSIX compliant and have /bin/sh", which is literally all of the platforms we support, and there is precedent for demanding POSIX in the Online check (which requires posix /bin/true), and this is documented.

In order to not break existing sudoers allowlist matching, this is achieved via a custom Fabric Runner that simply spawns /bin/sh, sets up the desired locales into it, and then finally runs the command.

Connection.sudo() ends up calling the sudo binary within the /bin/sh shell, and inherits the locale as long as the sudoers configuration allows it (default configuration does).

This is the most ideal solution I could come up with to achieve this.