### PR TITLE
TUI DataTable Improvements, preserve cursor position during refresh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev16"
+version = "3.0.0.dev17"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -3,6 +3,8 @@ Inventory Screen Module
 """
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -565,6 +567,57 @@ class InventoryScreen(DataScreen):
             self.refresh_rows()
             screenflags.flag_screen_clean("inventory")
 
+    @contextmanager
+    def save_cursor(self, table: DataTable) -> Iterator[None]:
+        """
+        Save and restore cursor/scroll positions during table rebuilds.
+
+        Due to the way the DataTable widget works in our current
+        implementation, we favor rebuilding the table entirely from
+        scratch every time the data it displays is refreshed, due to
+        filtering, sorting, and updates being made complex in the
+        context of modal/suspended screens.
+
+        Clearing the table resets the row cursor and scroll to 0.
+        This context manager captures these values and attempts to
+        restore them after the table is rebuilt, if at all possible.
+        """
+        try:
+            selected = table.coordinate_to_cell_key(
+                Coordinate(table.cursor_row, 0)
+            ).row_key.value
+        except (CellDoesNotExist, RowDoesNotExist):
+            logger.debug(
+                "Cursor row %s is not valid, nothing to save.",
+                table.cursor_row,
+            )
+            selected = None
+
+        scroll_y = table.scroll_y
+
+        yield
+
+        if selected is None:
+            logger.debug("No current selection, nothing to restore.")
+            return
+
+        try:
+            row_index = table.get_row_index(selected)
+        except RowDoesNotExist:
+            logger.debug(
+                "Previously selected host '%s' is no longer in the table, "
+                "not restoring cursor.",
+                selected,
+            )
+            return
+
+        # Textual auto-clamps scroll_y to max scrollable so we can
+        # restore it directly without worrying about the table being
+        # shorter than before. It also will bring the select row into
+        # view if it is outside the current scroll window on its own.
+        table.move_cursor(row=row_index, scroll=False)
+        table.scroll_y = scroll_y
+
     def refresh_rows(self, task: str | None = None, notify: bool = True) -> None:
         """Repopulate all rows in the data table from the inventory."""
 
@@ -600,11 +653,11 @@ class InventoryScreen(DataScreen):
 
         table = self.query_one(DataTable)
 
-        # Clear table but keep columns
-        table.clear(columns=False)
-
-        # Repopulate with filtered hosts
-        self._populate_table(table, hosts)
+        # Rebuild the table with the refreshed data, attempting to
+        # preserve the selected row and scroll position if possible.
+        with self.save_cursor(table):
+            table.clear(columns=False)
+            self._populate_table(table, hosts)
 
         if task:
             logger.debug("Updated data table due to task: %s", task)

--- a/src/exosphere/ui/inventory.py
+++ b/src/exosphere/ui/inventory.py
@@ -3,11 +3,11 @@ Inventory Screen Module
 """
 
 import logging
-import re
 
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Container, Grid, Vertical
+from textual.coordinate import Coordinate
 from textual.css.query import NoMatches
 from textual.events import Key
 from textual.screen import Screen
@@ -20,7 +20,7 @@ from textual.widgets import (
     ListItem,
     ListView,
 )
-from textual.widgets.data_table import RowDoesNotExist
+from textual.widgets.data_table import CellDoesNotExist, RowDoesNotExist, RowKey
 
 from exosphere import context
 from exosphere.inventory import FilterMode, SortField
@@ -247,6 +247,8 @@ class HostDetailsPanel(Screen):
     def __init__(self, host: Host) -> None:
         super().__init__()
         self.host = host
+        # Updates table row keys mapping
+        self._row_updates: dict[RowKey, Update] = {}
 
     def compose(self) -> ComposeResult:
         """Compose the host details layout."""
@@ -339,11 +341,15 @@ class HostDetailsPanel(Screen):
             "Package Update",
         )
 
-        # Populate the updates table with available updates
+        # Populate the updates table with available updates.
+        # We store the auto key for each row in a mapping to facilitate
+        # retrieval in later calls and event handling.
+        self._row_updates.clear()
         for update in update_list:
-            updates_table.add_row(
+            row_key = updates_table.add_row(
                 f"[red]{update.name}[/red]" if update.security else update.name
             )
+            self._row_updates[row_key] = update
 
     def on_key(self, event: Key) -> None:
         """Handle key presses to return to the inventory screen."""
@@ -353,24 +359,9 @@ class HostDetailsPanel(Screen):
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         """Handle row selection in the updates data table."""
 
-        # Retrieve the selected row by automatically generated key
-        table = self.query_one(DataTable)
-        row_data = table.get_row(event.row_key)
-
-        # Extract the update name, removing Rich markup if present
-        update_display_name = row_data[0]  # First column
-        update_name = re.sub(r"\[/?[^\]]*\]", "", update_display_name)
-
-        logger.debug("Selected update name: %s", update_name)
-
-        if not self.host:
-            logger.error("Host is not initialized, cannot select update.")
-            self.app.push_screen(ErrorScreen("Host is not initialized."))
-            return
-
-        update: Update | None = next(
-            (u for u in self.host.updates if u.name == update_name), None
-        )
+        # Resolve the selected row via its RowKey, set up when the table
+        # was populated.
+        update = self._row_updates.get(event.row_key)
 
         if update is None:
             logger.error("Update not found for host '%s'.", self.host.name)
@@ -520,24 +511,33 @@ class InventoryScreen(DataScreen):
             return None
 
         try:
-            row = table.get_row_at(table.cursor_row)
-        except RowDoesNotExist:
+            cell_key = table.coordinate_to_cell_key(Coordinate(table.cursor_row, 0))
+        except (CellDoesNotExist, RowDoesNotExist):
             logger.debug(
                 "Cursor row %s is not valid, no host to select.", table.cursor_row
             )
             return None
 
-        # First column is the (plain, unmarked) host name.
-        return context.inventory.get_host(str(row[0]))
+        # Rows are keyed by host name (the inventory's primary key).
+        # Unlike textual ids, the row key has no specific rules for
+        # allowed character, so we can use it verbatim.
+        host_name = cell_key.row_key.value
+        if host_name is None:
+            logger.debug("Cursor row has no host-name key, no host to select.")
+            return None
+
+        return context.inventory.get_host(host_name)
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         """Handle row selection in the data table."""
 
-        # Retrieve the selected row by automatically generated key
-        table = self.query_one(DataTable)
-        row_data = table.get_row(event.row_key)
+        # Rows are keyed by host name (the inventory's primary key).
+        host_name = event.row_key.value
 
-        host_name = row_data[0]  # First column is the host name
+        if not host_name:
+            logger.error("Selected row has no host-name key, cannot select row.")
+            self.app.push_screen(ErrorScreen("Selected row has no usable host name!"))
+            return
 
         if not context.inventory:
             logger.error("Inventory is not initialized, cannot select row.")
@@ -765,11 +765,13 @@ class InventoryScreen(DataScreen):
                 "[green]Online[/green]" if host.online else "[red]Offline[/red]"
             )
 
-            # Append reboot indicator if state indicates it. Kept off the
-            # name column, which is used verbatim as the row selection key.
+            # Append reboot indicator if state indicates it.
             if host.needs_reboot:
                 status_str += " [red]![/red]"
 
+            # Key each row by host name (the inventory's primary key) so
+            # selection survives sorting/filtering and is decoupled from
+            # the displayed cell text.
             table.add_row(
                 host.name,
                 maybe_unknown(host.os, host.supported),
@@ -778,4 +780,5 @@ class InventoryScreen(DataScreen):
                 updates,
                 security_updates,
                 status_str,
+                key=host.name,
             )

--- a/tests/ui/test_inventory_ui.py
+++ b/tests/ui/test_inventory_ui.py
@@ -943,8 +943,6 @@ class TestSelectedHost:
         self, exc, mocker, setup_inventory_mock, inventory_screen
     ):
         """An out-of-range cursor row yields None rather than raising."""
-        from textual.widgets.data_table import RowDoesNotExist
-
         mock_table = mocker.Mock()
         mock_table.row_count = 3
         mock_table.cursor_row = 99
@@ -952,3 +950,52 @@ class TestSelectedHost:
         mocker.patch.object(inventory_screen, "query_one", return_value=mock_table)
 
         assert inventory_screen.get_selected_host() is None
+
+
+class TestSaveCursor:
+    """The cursor and scroll positions are preserved across table rebuilds."""
+
+    def _table(self, mocker, *, selected: str, scroll: float = 7.0):
+        """Build a DataTable mock whose cursor is a selection"""
+        table = mocker.Mock(spec=DataTable)
+        table.cursor_row = 0
+        cell_key = mocker.Mock()
+        cell_key.row_key.value = selected
+        table.coordinate_to_cell_key.return_value = cell_key
+        table.scroll_y = scroll
+        return table
+
+    def test_restores_cursor_and_scroll(self, inventory_screen, mocker):
+        """The selected host and scroll offset survive a rebuild."""
+        table = self._table(mocker, selected="server3", scroll=7.0)
+        table.get_row_index.return_value = 5
+
+        with inventory_screen.save_cursor(table):
+            table.scroll_y = 0.0  # simulate resetting the scroll
+
+        table.get_row_index.assert_called_once_with("server3")
+        table.move_cursor.assert_called_once_with(row=5, scroll=False)
+        assert table.scroll_y == 7.0
+
+    def test_host_no_longer_displayed(self, inventory_screen, mocker):
+        """A host filtered out by the rebuild leaves the cursor alone."""
+        table = self._table(mocker, selected="gone")
+        table.get_row_index.side_effect = RowDoesNotExist("gone")
+
+        with inventory_screen.save_cursor(table):
+            pass
+
+        table.move_cursor.assert_not_called()
+
+    def test_no_selection(self, inventory_screen, mocker):
+        """An empty/invalid cursor before the rebuild restores nothing."""
+        table = mocker.Mock(spec=DataTable)
+        table.cursor_row = 0
+        table.coordinate_to_cell_key.side_effect = CellDoesNotExist("empty")
+        table.scroll_y = 0.0
+
+        with inventory_screen.save_cursor(table):
+            pass
+
+        table.get_row_index.assert_not_called()
+        table.move_cursor.assert_not_called()

--- a/tests/ui/test_inventory_ui.py
+++ b/tests/ui/test_inventory_ui.py
@@ -11,6 +11,7 @@ accept it into my heart just yet.
 
 import pytest
 from textual.widgets import DataTable
+from textual.widgets.data_table import CellDoesNotExist, RowDoesNotExist
 
 from exosphere import context
 from exosphere.data import Update
@@ -523,10 +524,10 @@ class TestRefreshRows:
         updates_col = row_data[4]  # 5th column (0-indexed)
         assert "*" in updates_col  # Stale indicator
 
-    def test_refresh_rows_keeps_name_selectable(
+    def test_refresh_rows_keys_rows_by_host_name(
         self, inventory_screen, setup_inventory_mock, mocker
     ):
-        """Regression test: don't dick with the name column"""
+        """Rows are keyed by host name so selection resolves via RowKey."""
         mock_table = mocker.Mock(spec=DataTable)
         mocker.patch.object(inventory_screen, "query_one", return_value=mock_table)
         mock_app = mocker.Mock()
@@ -537,18 +538,13 @@ class TestRefreshRows:
             return_value=mock_app,
         )
 
-        # Flag the first host as needing a reboot, simulating a change
-        assert context.inventory is not None
-        first_host = context.inventory.hosts[0]
-        first_host.needs_reboot = True
-
         inventory_screen.refresh_rows()
 
-        first_row = mock_table.add_row.call_args_list[0][0]
-        name_col = first_row[0]
-
-        # Did you dick with the name column?
-        assert name_col == first_host.name
+        assert context.inventory is not None
+        for call, host in zip(
+            mock_table.add_row.call_args_list, context.inventory.hosts, strict=True
+        ):
+            assert call.kwargs["key"] == host.name
 
     def test_refresh_rows_no_matching_hosts(
         self, inventory_screen, setup_inventory_mock, mocker
@@ -902,16 +898,20 @@ class TestSelectedHost:
         self, mocker, setup_inventory_mock, inventory_screen
     ):
         """The host under the row cursor is resolved from the inventory."""
+        from textual.coordinate import Coordinate
+
         mock_table = mocker.Mock()
         mock_table.row_count = 3
         mock_table.cursor_row = 1
-        mock_table.get_row_at.return_value = ["testserver2", "linux", "debian"]
+        cell_key = mocker.Mock()
+        cell_key.row_key.value = "testserver2"
+        mock_table.coordinate_to_cell_key.return_value = cell_key
         mocker.patch.object(inventory_screen, "query_one", return_value=mock_table)
 
         host = inventory_screen.get_selected_host()
 
         assert host is setup_inventory_mock.get_host("testserver2")
-        mock_table.get_row_at.assert_called_once_with(1)
+        mock_table.coordinate_to_cell_key.assert_called_once_with(Coordinate(1, 0))
 
     def test_get_selected_host_no_inventory(self, mocker, inventory_screen):
         """No inventory yields None."""
@@ -938,8 +938,9 @@ class TestSelectedHost:
         )
         assert inventory_screen.get_selected_host() is None
 
+    @pytest.mark.parametrize("exc", [CellDoesNotExist, RowDoesNotExist])
     def test_get_selected_host_invalid_cursor_row(
-        self, mocker, setup_inventory_mock, inventory_screen
+        self, exc, mocker, setup_inventory_mock, inventory_screen
     ):
         """An out-of-range cursor row yields None rather than raising."""
         from textual.widgets.data_table import RowDoesNotExist
@@ -947,7 +948,7 @@ class TestSelectedHost:
         mock_table = mocker.Mock()
         mock_table.row_count = 3
         mock_table.cursor_row = 99
-        mock_table.get_row_at.side_effect = RowDoesNotExist("bad row")
+        mock_table.coordinate_to_cell_key.side_effect = exc("bad row")
         mocker.patch.object(inventory_screen, "query_one", return_value=mock_table)
 
         assert inventory_screen.get_selected_host() is None

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev16"
+version = "3.0.0.dev17"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Includes the following changes:

- Use explicit Host.name based key on DataTable rows, to decouple from row value. This is also the primary key for the inventory, and is guaranteed unique, and therefore is a good fit.
- When the data the table displays is refreshed, the cursor positon and scroll value are now preserved instead of being reset to 0, 0.

See commit logs for more details.