### PR TITLE
CLI: Cleanup and improve help text for commands

### DIFF
--- a/src/exosphere/commands/config.py
+++ b/src/exosphere/commands/config.py
@@ -21,7 +21,7 @@ from exosphere.editing import EditorError, open_in_editor
 ROOT_HELP = """
 Configuration-related Commands
 
-Commands to inspect the currently loaded configuration.
+Commands to inspect or modify the currently loaded configuration.
 """
 
 app = App(name="config", help=ROOT_HELP, help_flags=["--help"])
@@ -35,7 +35,7 @@ def show(
     full: Annotated[bool, Parameter(name=["--full", "-f"], negative="")] = False,
 ) -> int:
     """
-    Show the current configuration.
+    Show the current configuration
 
     Displays the current configuration options, or the value of a specific option
     if specified.
@@ -79,7 +79,7 @@ def show(
 @app.command
 def source(*, env: bool = True) -> None:
     """
-    Show the configuration source, where it was loaded from.
+    Show the configuration source, where it was loaded from
 
     Displays the path of the configuration file loaded, if any, and
     any environment variables that affect the configuration.
@@ -119,7 +119,7 @@ def source(*, env: bool = True) -> None:
 @app.command
 def paths() -> None:
     """
-    Show the paths of application directories.
+    Show the paths of application directories
 
     Will display the platform-specific filesystem paths that exosphere
     uses for configuration, state, logs, and cache.
@@ -144,7 +144,7 @@ def diff(
     full: Annotated[bool, Parameter(name=["--full", "-f"], negative="")] = False,
 ) -> None:
     """
-    Show the differences between the current configuration and the defaults.
+    Show the differences between the current configuration and the defaults
 
     Exosphere follows convention over configuration, so your configuration
     file can exclusively contain the options you want to change.
@@ -200,14 +200,14 @@ def edit(
     ] = True,
 ) -> int:
     """
-    Open the current configuration file in an editor.
+    Open the current configuration file in an editor
 
     Launches your text editor against the currently loaded
     configuration file. If no configuration file is loaded, the default
     platform path is opened instead, letting you create one from
     scratch.
 
-    The editor to use is determined  from the ``editor`` configuration
+    The editor to use is determined from the ``editor`` configuration
     option and then falls back to the ``VISUAL`` and ``EDITOR``
     environment variables, then finally, a platform default.
 

--- a/src/exosphere/commands/connections.py
+++ b/src/exosphere/commands/connections.py
@@ -59,7 +59,7 @@ def show(
     ] = False,
 ) -> int:
     """
-    Show SSH connection state for inventory hosts.
+    Show SSH connection state for inventory hosts
 
     Display the current SSH connection state for specified hosts, or
     all hosts if none are specified.

--- a/src/exosphere/commands/host.py
+++ b/src/exosphere/commands/host.py
@@ -32,9 +32,12 @@ SPINNER_ARGS = (
 )
 
 ROOT_HELP = """
-Host Management Commands
+Host Operations Commands
 
 Commands to query, refresh and discover individual hosts.
+
+``show`` is the primary command to display the current state of a host
+in the inventory.
 """
 
 app = App(name="host", help=ROOT_HELP, help_flags=["--help"])
@@ -163,10 +166,10 @@ def show(
     ] = False,
 ) -> int:
     """
-    Show details of a specific host.
+    Show detailed state of a specific host
 
     This command retrieves the host by name from the inventory
-    and displays its details in a rich format.
+    and displays its details in a rich format on the terminal.
 
     Parameters
     ----------
@@ -214,7 +217,7 @@ def show(
 @app.command
 def discover(host: HostArg, /) -> int:
     """
-    Gather platform data for host.
+    Detect and gather platform data for a host
 
     This command retrieves the host by name from the inventory
     and synchronizes its platform data, such as OS, version and
@@ -251,22 +254,25 @@ def refresh(
     host: HostArg,
     /,
     *,
-    full: Annotated[bool, Parameter(name=["--sync", "-s"], negative="")] = False,
+    sync: Annotated[bool, Parameter(name=["--sync", "-s"], negative="")] = False,
     discover: Annotated[
         bool, Parameter(name=["--discover", "-d"], negative="")
     ] = False,
 ) -> int:
     """
-    Refresh the updates for a specific host.
+    Refresh the state and update data for a specific host
 
     This command retrieves the host by name from the inventory
-    and refreshes its available updates.
+    and refreshes its state and available updates.
+
+    If `--sync` is specified, the package repositories will also be
+    synchronized remotely.
 
     Parameters
     ----------
     host
         Host from inventory to refresh
-    full
+    sync
         Also sync package repositories
     discover
         Also refresh platform information
@@ -292,7 +298,7 @@ def refresh(
 
             progress.stop_task(task)
 
-        if full:
+        if sync:
             task = progress.add_task(
                 f"Syncing package repositories for '{host.name}'", total=None
             )
@@ -336,12 +342,10 @@ def refresh(
 @app.command
 def ping(host: HostArg, /) -> None:
     """
-    Ping a specific host to check its reachability.
+    Ping a specific host to check connectivity and online status
 
-    This command will also update a host's online status
-    based on the ping result.
-
-    The ping status is based on ssh connectivity.
+    The ping status is based on ssh connectivity, and will update
+    the host's online status in the inventory accordingly.
 
     Parameters
     ----------

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -38,10 +38,13 @@ ERROR_STYLE = {
 SORT_COLUMNS = ", ".join(field.value for field in SortField)
 
 ROOT_HELP = """
-Inventory and Bulk Management Commands
+Inventory and Bulk Operations Commands
 
 Commands to bulk query, discover and refresh hosts in the inventory.
 Most commands accept an optional list of host names to operate on.
+
+``status`` is the primary command to display the current state of hosts
+in the inventory.
 """
 
 app = App(name="inventory", help=ROOT_HELP, help_flags=["--help"])
@@ -50,7 +53,7 @@ app = App(name="inventory", help=ROOT_HELP, help_flags=["--help"])
 @app.command
 def discover(*names: HostArg) -> int:
     """
-    Gather platform information for hosts
+    Detect and gather platform information for hosts
 
     On a fresh inventory start, this needs to be done at least once
     before operations can be performed on the hosts. It can also be
@@ -114,7 +117,7 @@ def refresh(
     verbose: Annotated[bool, Parameter(name=["--verbose", "-v"], negative="")] = False,
 ) -> int:
     """
-    Refresh the update data for all hosts
+    Refresh the state and update data for hosts
 
     Connects to hosts in the inventory and retrieves pending package
     updates.
@@ -123,9 +126,10 @@ def refresh(
     System flavor, version, package manager) will also be refreshed.
     Also refreshes the online status in the process.
 
-    If `--sync` is specified, the package repositories will also be synced.
+    If `--sync` is specified, the package repositories will also be
+    synchronized remotely.
 
-    Syncing the package repositories involves invoking whatever mechanism
+    Synchronizing the package repositories involves invoking whatever mechanism
     the package manager uses to achieve this, and can be a very expensive
     operation, which may take a long time, especially on large inventories
     with a handful of slow hosts.
@@ -233,7 +237,7 @@ def refresh(
 @app.command
 def ping(*names: HostArg) -> int:
     """
-    Ping all hosts in the inventory
+    Check connectivity and online status of hosts
 
     Attempts to connect to all hosts in the inventory.
     On failure, the affected host will be marked as offline.
@@ -241,9 +245,12 @@ def ping(*names: HostArg) -> int:
     You can use this command to quickly check whether or not
     hosts are reachable and online.
 
-    Invoke this to update the online status of hosts if
-    any have gone offline and exosphere refuses to run
-    an operation on them.
+    You can also invoke this command to explicitly refresh the Online
+    status of hosts in the inventory.
+
+    The connectivity check is based on SSH reachability, and the
+    criteria for a host being considered online is "ready to execute
+    commands via SSH".
 
     Parameters
     ----------
@@ -335,7 +342,7 @@ def status(
     full: Annotated[bool, Parameter(name=["--full", "-f"], negative="")] = False,
 ) -> int:
     """
-    Show hosts and their status
+    Show inventory hosts and their status
 
     Display a nice table with the current state of all the hosts
     in the inventory, including their package update counts, their
@@ -493,9 +500,9 @@ def save() -> None:
     Since this is enabled by default, you will rarely need to invoke this
     manually.
 
-    This command is only available in interactive mode, as the inventory
-    state is not persisted between separate CLI invocations when autosave
-    is disabled.
+    This command is only available in interactive mode, as the
+    inventory state is not persisted between separate CLI invocations
+    when autosave is disabled.
     """
     save_inventory_state()
 
@@ -506,7 +513,7 @@ def clear(
     force: Annotated[bool, Parameter(name=["--force", "-f"], negative="")] = False,
 ) -> int:
     """
-    Clear the inventory state and cache file
+    Clear the inventory state and cache file (reset state)
 
     This will empty the inventory cache file and re-initialize
     all hosts from scratch.

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -89,7 +89,7 @@ def generate(
     navigation: Annotated[bool, Parameter(group=OUTPUT_GROUP)] = True,
 ) -> int:
     """
-    Generate a report of the current inventory state.
+    Generate a report of the current inventory state
 
     The report can be generated in various formats, including html for
     for a pretty self-contained document, json for easy integration

--- a/src/exosphere/commands/sudo.py
+++ b/src/exosphere/commands/sudo.py
@@ -17,10 +17,20 @@ from exosphere.providers.factory import PkgManagerFactory
 from exosphere.security import SudoPolicy, check_sudo_policy, has_sudo_flag
 
 ROOT_HELP = """
-Sudo Policy Management
+Sudo Policy Management Commands
 
-Commands to view Sudo Policies, check resultant host policies,
-list provider requirements, and generate sudoers snippets.
+Exosphere providers may require sudo privileges to execute certain
+operations on remote systems. These commands allow you to inspect,
+validate and generate suitable sudoers configurations.
+
+Exosphere has a global Sudo Policy that dictates how operations
+requiring those privileges are handled (the default is to skip them).
+
+Individual hosts may override the global Sudo Policy with their own
+Sudo Policy in the inventory configuration.
+
+For more details, see the ``Sudo Policies and Privileges`` section of
+the Exosphere documentation.
 """
 
 app = App(name="sudo", help=ROOT_HELP, help_flags=["--help"])
@@ -129,7 +139,7 @@ def _get_username(user: str | None, host: Host | None = None) -> str:
 @app.command
 def policy() -> None:
     """
-    Show the current global Sudo Policy.
+    Show the current global Sudo Policy
 
     This command will display the current global Sudo Policy in effect.
     Individual hosts may override this with their own Sudo Policy.
@@ -140,7 +150,7 @@ def policy() -> None:
 @app.command
 def check(host: HostArg, /) -> int:
     """
-    Check the effective Sudo Policies for a given host.
+    Check the effective Sudo Policies for a given host
 
     The command will take in consideration the current global Sudo Policy and the
     host-specific Sudo Policy (if defined) to determine if the host can execute
@@ -243,10 +253,11 @@ def check(host: HostArg, /) -> int:
 @app.command
 def providers(name: str | None = None, /) -> int:
     """
-    Show Sudo Policy requirements for available providers.
+    Show Sudo Policy requirements for available providers
 
     Some providers require sudo privileges to execute certain operations.
-    You can use this command to what they are, if applicable.
+    You can use this command to enumerate these requirements, if
+    applicable.
 
     Parameters
     ----------
@@ -305,7 +316,7 @@ def generate(
     user: Annotated[str | None, Parameter(name=["--user", "-u"])] = None,
 ) -> int:
     """
-    Generate a sudoers configuration for passwordless operations.
+    Generate a sudoers configuration for passwordless operations
 
     Creates snippet suitable for /etc/sudoers.d/* on target systems.
 

--- a/src/exosphere/commands/ui.py
+++ b/src/exosphere/commands/ui.py
@@ -24,7 +24,7 @@ app = App(name="ui", help=ROOT_HELP, help_flags=["--help"])
 @app.default
 def run_tui() -> None:
     """
-    Start the Exosphere Text-based User Interface (TUI).
+    Start the Exosphere Text-based User Interface (TUI)
 
     This is the entry point for the 'ui' command.
     """

--- a/src/exosphere/commands/version.py
+++ b/src/exosphere/commands/version.py
@@ -35,7 +35,7 @@ DOCS_URL = (
 @app.default
 def version_default() -> None:
     """
-    Show the current version of Exosphere.
+    Show the current version of Exosphere
 
     Displays the currently installed version. Use 'version check' to check
     for updates on PyPI.

--- a/src/exosphere/repl.py
+++ b/src/exosphere/repl.py
@@ -567,7 +567,7 @@ class ExosphereREPL:
                 title_align="left",
                 border_style="dim",
             )
-            self.console.print("\nAvailable modules during interactive use:\n")
+            self.console.print("\nAvailable commands during interactive use:\n")
             self.console.print(panel)
 
         # Spacing for better readability


### PR DESCRIPTION
Clean up a few terminology inconsistencies in the help text for various commands, and improve the clarity of some descriptions.

Formatting inconsistencies were also resolved, such as consistently removing trailing periods from top level command descriptions.

Commands that were very good at avoiding describing their purpose over their immediate functionality were reworded to hopefully be more helpful to a user who is simply exploring the CLI. ("sudo" and its subcommands was the worst offender here).