### PR TITLE
Docs: Reorganize TOC, add Concepts, docs refresh

### DIFF
--- a/docs/source/_static/concepts-lifecycle.svg
+++ b/docs/source/_static/concepts-lifecycle.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 470" font-family="'Segoe UI','DejaVu Sans',Verdana,sans-serif">
+  <defs>
+    <marker id="amsg" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#566673"/>
+    </marker>
+  </defs>
+
+  <!-- lifelines -->
+  <g stroke="#b9c4cc" stroke-width="1.2" stroke-dasharray="4 4">
+    <line x1="110" y1="76" x2="110" y2="408"/>
+    <line x1="360" y1="76" x2="360" y2="408"/>
+    <line x1="610" y1="76" x2="610" y2="408"/>
+  </g>
+
+  <!-- participants -->
+  <rect x="45" y="30" width="130" height="44" rx="6" fill="#e8f4ef" stroke="#009568" stroke-width="1.5"/>
+  <text x="110" y="58" text-anchor="middle" font-size="14" fill="#3d3d3d">Cache</text>
+  <rect x="295" y="30" width="130" height="44" rx="6" fill="#009568" stroke="#00795a" stroke-width="1.5"/>
+  <text x="360" y="58" text-anchor="middle" font-size="14" font-weight="600" fill="#fff">Exosphere</text>
+  <rect x="545" y="30" width="130" height="44" rx="6" fill="#e8f4ef" stroke="#009568" stroke-width="1.5"/>
+  <text x="610" y="58" text-anchor="middle" font-size="14" fill="#3d3d3d">Host</text>
+
+  <!-- Discover -->
+  <text x="485" y="103" text-anchor="middle" font-size="13" fill="#3d3d3d">Discover</text>
+  <line x1="362" y1="110" x2="608" y2="110" stroke="#566673" stroke-width="1.5" marker-end="url(#amsg)"/>
+
+  <!-- response -->
+  <text x="485" y="133" text-anchor="middle" font-size="13" fill="#3d3d3d">OS, version, package manager</text>
+  <line x1="608" y1="140" x2="362" y2="140" stroke="#566673" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#amsg)"/>
+
+  <!-- loop frame -->
+  <rect x="80" y="160" width="585" height="250" rx="2" fill="none" stroke="#009568" stroke-width="1.3"/>
+  <path d="M80,160 h64 v14 l-8,8 H80 z" fill="#009568"/>
+  <text x="98" y="177" font-size="12" font-weight="700" fill="#fff">loop</text>
+  <text x="158" y="177" font-size="12" font-style="italic" fill="#009568">Refresh cycle</text>
+
+  <!-- opt frame -->
+  <rect x="305" y="192" width="345" height="66" rx="2" fill="none" stroke="#2ea6e8" stroke-width="1.2"/>
+  <path d="M305,192 h56 v14 l-8,8 H305 z" fill="#2ea6e8"/>
+  <text x="320" y="209" font-size="12" font-weight="700" fill="#fff">opt</text>
+  <text x="373" y="209" font-size="12" font-style="italic" fill="#1f7fb5">Optional</text>
+
+  <!-- Repo Sync -->
+  <text x="485" y="237" text-anchor="middle" font-size="13" fill="#3d3d3d">Repo Sync</text>
+  <line x1="362" y1="244" x2="608" y2="244" stroke="#566673" stroke-width="1.5" marker-end="url(#amsg)"/>
+
+  <!-- Refresh -->
+  <text x="485" y="293" text-anchor="middle" font-size="13" fill="#3d3d3d">Refresh (query updates)</text>
+  <line x1="362" y1="300" x2="608" y2="300" stroke="#566673" stroke-width="1.5" marker-end="url(#amsg)"/>
+
+  <!-- Available updates -->
+  <text x="485" y="323" text-anchor="middle" font-size="13" fill="#3d3d3d">Available updates</text>
+  <line x1="608" y1="330" x2="362" y2="330" stroke="#566673" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#amsg)"/>
+
+  <!-- Store results -->
+  <text x="235" y="363" text-anchor="middle" font-size="13" fill="#3d3d3d">Store results</text>
+  <line x1="358" y1="370" x2="112" y2="370" stroke="#566673" stroke-width="1.5" marker-end="url(#amsg)"/>
+
+  <!-- note -->
+  <rect x="90" y="420" width="540" height="40" rx="3" fill="#ccddf3" stroke="#7ba0cf" stroke-width="1.2"/>
+  <text x="360" y="437" text-anchor="middle" font-size="12.5" fill="#003274">Status and reports are served from the cache,</text>
+  <text x="360" y="453" text-anchor="middle" font-size="12.5" fill="#003274">with no host access required</text>
+</svg>

--- a/docs/source/_static/concepts-overview.svg
+++ b/docs/source/_static/concepts-overview.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 360" font-family="'Segoe UI','DejaVu Sans',Verdana,sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#566673"/>
+    </marker>
+  </defs>
+
+  <!-- Your machine group -->
+  <rect x="40" y="92" width="232" height="176" rx="12" fill="#edf4f0" stroke="#cdddd5" stroke-width="1.5"/>
+  <text x="156" y="116" text-anchor="middle" font-size="15" font-weight="600" fill="#009568">Your machine</text>
+
+  <!-- SSH Agent -->
+  <rect x="71" y="132" width="170" height="46" rx="6" fill="#e8f4ef" stroke="#009568" stroke-width="1.5"/>
+  <text x="156" y="160" text-anchor="middle" font-size="14" fill="#3d3d3d">SSH Agent</text>
+
+  <!-- Exosphere -->
+  <rect x="71" y="198" width="170" height="46" rx="6" fill="#009568" stroke="#00795a" stroke-width="1.5"/>
+  <text x="156" y="226" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Exosphere</text>
+
+  <!-- Hosts -->
+  <rect x="498" y="40" width="182" height="56" rx="6" fill="#e8f4ef" stroke="#009568" stroke-width="1.5"/>
+  <text x="589" y="73" text-anchor="middle" font-size="14" fill="#3d3d3d">Debian host</text>
+
+  <rect x="498" y="152" width="182" height="56" rx="6" fill="#e8f4ef" stroke="#009568" stroke-width="1.5"/>
+  <text x="589" y="185" text-anchor="middle" font-size="14" fill="#3d3d3d">FreeBSD host</text>
+
+  <rect x="498" y="264" width="182" height="56" rx="6" fill="#e8f4ef" stroke="#009568" stroke-width="1.5"/>
+  <text x="589" y="297" text-anchor="middle" font-size="14" fill="#3d3d3d">RHEL host</text>
+
+  <!-- SSH connections from the "Your machine" box -->
+  <line x1="272" y1="180" x2="496" y2="68" stroke="#566673" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="272" y1="180" x2="496" y2="180" stroke="#566673" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="272" y1="180" x2="496" y2="292" stroke="#566673" stroke-width="1.6" marker-end="url(#arrow)"/>
+
+  <!-- SSH labels -->
+  <g font-size="12" fill="#566673">
+    <rect x="366" y="115" width="36" height="18" rx="3" fill="#f5f5f5"/>
+    <text x="384" y="128" text-anchor="middle">SSH</text>
+    <rect x="366" y="171" width="36" height="18" rx="3" fill="#f5f5f5"/>
+    <text x="384" y="184" text-anchor="middle">SSH</text>
+    <rect x="366" y="227" width="36" height="18" rx="3" fill="#f5f5f5"/>
+    <text x="384" y="240" text-anchor="middle">SSH</text>
+  </g>
+</svg>

--- a/docs/source/cachefile.rst
+++ b/docs/source/cachefile.rst
@@ -1,5 +1,5 @@
 Managing Cache
-===============
+==============
 
 Exosphere saves the state of all hosts in a cache file, stored on disk.
 This allows the software to remember the state of hosts and updates between runs.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -107,7 +107,7 @@ repositories on each host, before fetching the update status.
 .. admonition:: Note
 
    The ``--sync`` option may require elevated privileges (sudo) on some platforms.
-   See the :doc:`connections` page for more details on how to configure this.
+   See the :doc:`sudo` page for more details on how to configure this.
    This operation may also take quite a long time, depending on the number of
    hosts and their specifications, as well as the network speed.
 
@@ -139,9 +139,9 @@ available.
 
    Two markers may appear in the table, as noted in its legend:
 
-   - ``*`` next to the update counts marks **stale** data — the host has not
+   - ``*`` next to the update counts marks **stale** data --- the host has not
      been refreshed in a while (configurable, see :option:`stale_threshold`).
-   - ``!`` next to a host's status marks a **pending reboot** — the host needs
+   - ``!`` next to a host's status marks a **pending reboot** --- the host needs
      to be rebooted (for example after a kernel update).
 
 You can also select one or more specific hosts by providing their names as arguments:

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -1,0 +1,95 @@
+How Exosphere Works
+===================
+
+Exosphere runs entirely from your own machine. There is no agent to install,
+no server to keep running, and nothing extra living on the remote hosts ---
+everything happens over plain SSH, driven by the :doc:`cli` or :doc:`ui` on
+your workstation or laptop.
+
+This page offers a quick overview of how the pieces fit together, so the
+commands in the :doc:`quickstart` (and everywhere else) make sense.
+
+Overview
+--------
+
+.. only:: not latex
+
+   .. figure:: _static/concepts-overview.svg
+      :alt: Exosphere on your machine fanning out to each host over SSH
+      :align: center
+
+      Everything runs from your machine.
+
+Your machine connects to each host over SSH, runs a handful of ordinary, mostly
+read-only commands (the kind you could type yourself), and brings the results
+back home. The hosts need nothing installed beyond what they already ship
+with: an SSH server and a POSIX shell.
+
+See :doc:`supportedos` for the specifics of what is required on each end,
+as well as the :doc:`connections` page for details on SSH access.
+
+Concepts
+--------
+
+Three concepts carry most of the weight:
+
+**Host**
+    One remote system Exosphere connects to.
+
+**Inventory**
+    The full collection of hosts, defined in your :doc:`configuration`.
+    Most commands operate on the whole inventory unless you name specific hosts.
+
+**Provider**
+    The platform-specific adapter (``apt``, ``dnf``/``yum``, ``pkg``,
+    ``pkg_add``) that knows how to ask a given host about its updates. The
+    right one is detected automatically during discovery --- you never pick one
+    by hand.
+
+The full vocabulary lives in the :doc:`glossary`, but most of it should be
+fairly self-explanatory. Details about the providers are available in the
+:doc:`providers` section.
+
+Usage Lifecycle
+---------------
+
+.. only:: not latex
+
+   .. figure:: _static/concepts-lifecycle.svg
+      :alt: Discover once, then an optional repo sync, refresh, and store to the cache on each run
+      :align: center
+
+      Discover once, then refresh on demand. Reporting reads from the cache.
+
+Working with your hosts follows a simple loop:
+
+1. **Discover**: connect once and detect the operating system, version,
+   flavor and package manager, then assign the right provider. You only repeat
+   this if something fundamental changes on the host.
+2. **Refresh**: ask the provider what updates are available, sort out which
+   ones are security-related, and note whether a reboot is pending. This is
+   entirely read-only.
+3. **Repository Sync** *(optional)*: refresh the host's own package metadata
+   first, so the next Refresh sees the very latest. This is the one step that
+   may require :doc:`sudo` on some platforms.
+4. **View / Report**: look at the results, via the :doc:`cli` status tables,
+   the interactive :doc:`ui`, or generated :doc:`reports <reporting>`.
+
+Everything Discover and Refresh learn is saved to a local **cache**, so viewing
+status and generating reports never needs to touch the hosts again. This is
+handy for scheduled reports, or simply running from a context where your SSH
+agent is not available. See :doc:`cachefile` for more details.
+
+What Exosphere Is Not
+---------------------
+
+Exosphere reports --- it does not act. It will happily tell you what needs
+patching, where, and how urgently, but it will never apply an update or change
+a host's configuration on your behalf. Pushing those changes out is left to
+existing tooling built for the job, such as `Ansible`_ and similar automation
+frameworks, or `unattended-upgrades`_ and similar.
+
+See the :doc:`faq` for more on this distinction, and why it is a deliberate one.
+
+.. _Ansible: https://www.ansible.com/
+.. _unattended-upgrades: https://wiki.debian.org/UnattendedUpgrades

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -243,7 +243,7 @@ and examples of how to set them in the configuration file.
     you must configure your sudoers file to allow the user Exosphere connects as
     to run those commands with ``NOPASSWD:`` in the sudoers file.
 
-    More details on how to configure this can be found in the :doc:`connections`
+    More details on how to configure this can be found in the :doc:`sudo`
     documentation.
 
     .. admonition:: Note

--- a/docs/source/connections.rst
+++ b/docs/source/connections.rst
@@ -1,14 +1,16 @@
-Connections and Privileges
-==========================
+Connections and Authentication
+==============================
 
 This section of the documentation describes the authentication mechanisms (or lack thereof)
-provided by Exosphere, as well as how Privileges and Sudo are handled.
+provided by Exosphere, as well as how SSH connections are established and reused.
+
+For how privileges and sudo are handled, see :doc:`sudo`.
 
 Connecting to systems
 ---------------------
 
 Exosphere uses SSH to connect to remote hosts, using the lovely `Fabric`_ library.
-The intended authentication method is to use SSH keys, which should be loaded into your SSH agent.
+The intended authentication method is to use SSH keys, which should be loaded into your **SSH agent**.
 
 Exosphere **purposefully does not support password authentication** in any of its subsystems,
 to avoid having to deal with the complexities of storing credentials, or prompting for them
@@ -32,7 +34,7 @@ are as follows:
 Using SSH Agents
 ----------------
 
-An SSH agent is a program that loads your SSH keys into memory, usually with your login session
+An **SSH agent** is a program that loads your SSH keys into memory, usually with your login session
 on your workstation or laptop, allowing you to connect to remote hosts without having to
 enter your passphrase every time. This is instrumental to many SSH automation tools and
 workflows.
@@ -99,8 +101,6 @@ pinpoint the exact issue with authentication or connectivity.
 .. _Windows OpenSSH Agent: https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement
 .. _SSH Client feature: https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
 
-.. _sudo-policies-and-privileges:
-
 .. _ssh_pipelining_docs:
 
 SSH Pipelining
@@ -154,180 +154,3 @@ See the `connections` command help for more details.
 The configurable values for SSH Pipelining include the :ref:`maximum lifetime
 of idle connections <ssh_pipelining_lifetime_option>`, as well as the
 :ref:`interval at which they are reaped <ssh_pipelining_reap_interval_option>`.
-
-Sudo Policies and Privileges
-============================
-
-Exosphere and its provider modules try, as much as possible, to avoid requiring elevated
-privileges at all. Unfortunately, on some platforms, some operations that we rely on
-do require them.
-
-The following section describes how to configure the Sudo Policy for Exosphere as well
-as optionally grant the required privileges on the remote hosts.
-
-.. admonition:: Note
-
-    These instructions below are entirely optional, and you can absolutely use
-    Exosphere without ever setting up sudoers configuration or privileges.
-    You will just be limited to the operations that do not require
-    elevated privileges, which is the majority of them.
-
-Enumerating Providers and their Privileges
-------------------------------------------
-
-The documentation for :doc:`providers` includes details, but you can query this via the
-exosphere CLI and its ``sudo`` command. Here is an example below:
-
-.. code-block:: console
-
-    $ exosphere sudo providers
-                                    Providers Requirements
-    ┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
-    ┃ Provider ┃ Platform                       ┃ Sync Repositories ┃ Refresh Updates ┃
-    ┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
-    │ Apt      │ Debian/Ubuntu Derivatives      │ Requires Sudo     │ No Privileges   │
-    │ Pkg      │ FreeBSD                        │ Requires Sudo     │ No Privileges   │
-    │ PkgAdd   │ OpenBSD                        │ No Privileges     │ No Privileges   │
-    │ Dnf      │ Fedora/RHEL/CentOS Derivatives │ No Privileges     │ No Privileges   │
-    │ Yum      │ RHEL/CentOS 7 and earlier      │ No Privileges     │ No Privileges   │
-    └──────────┴────────────────────────────────┴───────────────────┴─────────────────┘
-
-For instance, we can see here that the ``Apt`` and ``Pkg`` providers require sudo privileges
-to sync repositories, but do not require any privileges to refresh updates.
-
-.. note::
-   The table above shows the privilege requirements for each operation type:
-
-   * **Sync Repositories**: Updating package repository metadata (e.g., ``apt-get update``)
-   * **Refresh Updates**: Checking for available package updates
-
-Configuring Sudo Policies
--------------------------
-
-The default Sudo Policy for exosphere is `skip`, :ref:`configured globally <default_sudo_policy_option>`.
-This means that Exosphere will not attempt to use sudo at all when running provider commands.
-
-This can also be configured per system, by setting the :ref:`sudo policy option <hosts_sudo_policy_option>`
-at the host level.
-
-There are currently two valid settings for the Sudo Policy options:
-
-* ``skip``: Do not use sudo at all, skip operations that require it and emit a warning in logs
-* ``nopasswd``: Assume sudoers configuration allows running the provider commands without a password
-
-If you want to be able to use Exosphere to run operations that require sudo privileges, you will
-need to configure sudoers on the remote host(s) where this applies to allow them to be run without
-a password.
-
-.. attention::
-
-    This can potentially expose your system to security risks if not configured properly.
-    See the section below for details on how to configure this safely.
-
-Generating a Sudoers configuration
-----------------------------------
-
-You can manually configure sudoers with ``NOPASSWD:`` as you wish, so long as it allows
-the commands specified in the :doc:`providers` documentation to run.
-
-However, since this can be a combination of tedious, risky and error-prone,
-Exosphere provides a helper command that will generate a sudoers snippet for you,
-for any host, or specific provider, while also allowing you to specify a username.
-
-To generate a sudoers configuration snippet for the ``Apt`` provider, for instance,
-with the username ``bigadmin``, you can run the following command:
-
-.. code-block:: console
-
-    $ exosphere sudo generate --provider apt --user bigadmin
-    # Generated for Debian/Ubuntu Derivatives
-    Cmnd_Alias EXOSPHERE_CMDS = /usr/bin/apt-get update
-    bigadmin ALL=(root) NOPASSWD: EXOSPHERE_CMDS
-
-You can then take this output and drop it in a file on the remote host, such as
-``/etc/sudoers.d/exosphere``, and then switch the Sudo Policy to ``nopasswd`` for that host.
-
-.. admonition:: On usernames
-
-    The username parameter is optional. If you do not specify it, the command will
-    try to use, in this order:
-
-    1. The username configured for the host, if any (when using ``--host``)
-    2. The username configured in the global configuration, if any
-    3. The current local username running the exosphere command
-
-You can also use the ``--host`` option to automatically detect the provider
-for a host and generate the appropriate sudoers snippet for it.
-
-For more details, see ``exosphere sudo generate --help``.
-
-Security Considerations
-^^^^^^^^^^^^^^^^^^^^^^^
-
-The generated sudoers configuration is designed to be as secure as possible:
-
-* **Specific commands only**: Only the exact commands needed by the provider are allowed
-* **Absolute paths**: Commands use full absolute paths (e.g., ``/usr/bin/apt-get``)
-* **Root user only**: Commands are restricted to run as ``root`` (not ``ALL``)
-* **No password required**: Uses ``NOPASSWD:`` to avoid credential storage/prompting
-* **Command aliases**: Uses ``Cmnd_Alias`` for better maintainability
-
-This approach is significantly more secure than granting broad sudo access, as it:
-
-* Limits the attack surface to specific commands that are known in advance
-* Prevents privilege escalation beyond the intended operations
-* Avoids the security risks of password-based authentication
-
-Alternatives
-^^^^^^^^^^^^
-
-If your relevant providers only require sudo privileges for repository synchronization,
-and you prefer not to use the sudoers configuration, you can still
-configure your remote systems to sync those repositories on a schedule.
-You will just not be able to use Exosphere to do it on-demand, but the
-repository contents should always be reasonably up to date.
-
-On Debian/Ubuntu systems, consider these options:
-
-* The `unattended-upgrades`_ package, which can be configured to automatically
-  run ``apt-get update`` and optionally ``apt-get upgrade`` on a schedule
-* The ``apt-config-auto-update`` package for simpler automatic update configuration
-* Custom cron jobs with ``apt-get update`` if you prefer manual control
-
-On FreeBSD, you can set up a cron job or periodic task to run
-``/usr/sbin/pkg update`` regularly.
-
-For other distributions, similar automated package management tools are available.
-
-How can I check what the effective Sudo Policy is for a given host?
--------------------------------------------------------------------
-
-You can use the ``sudo check`` helper command.
-
-As an example, to check the effective Sudo Policy for a host named ``bigserver``:
-
-.. code-block:: console
-
-    $ exosphere sudo check bigserver
-    Sudo Policy for bigserver
-
-     Global Policy:          skip
-     Host Policy:            nopasswd (local)
-     Package Manager:        apt
-
-     Can Sync Repositories:  Yes
-     Can Refresh Updates:    Yes
-
-This will tell you what the effective Sudo Policy is for that host, as well as
-where that is configured. For instance, in the example above, you can see the
-global policy is ``skip``, but the host policy has been set to ``nopasswd``
-locally, in the inventory host options.
-
-The global Sudo Policy can also be displayed via:
-
-.. code-block:: console
-
-    $ exosphere sudo policy
-    Global SudoPolicy: skip
-
-.. _unattended-upgrades: https://wiki.debian.org/UnattendedUpgrades

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -3,8 +3,11 @@ Frequently Asked Questions
 
 And also troubleshooting tips, in general.
 
+General Questions
+-----------------
+
 Can Exosphere help me apply the updates and patches?
-----------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Unfortunately, no. Exosphere is not a configuration management or automation
 tool, simply a reporting and aggregation tool.
@@ -16,8 +19,51 @@ make informed decisions about what needs patching, and when.
 This functionality is not planned, and left to frankly better tooling that
 already exists, such as `UnattendedUpgrades`_, `Ansible`_, `RunDeck`_, etc.
 
+Didn't Exosphere used to have a Web UI? What happened to it?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It was removed in version 3.0. The Web UI started as a neat curiosity more than
+a feature, but never left the experimental stage.
+
+It was always provided as a separate, opt-in, extra for the python packages,
+and installed and used by few, least of all the author.
+
+As the project matured, and new features started clashing with the way it was
+implemented, it became clear it should be removed instead of being left to rot
+in its current, janky, underdeveloped state.
+
+Why all the different config file formats?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The author is fond of yaml, but recognizes toml is gaining traction in the Python community.
+At this point also supporting json was so low effort that it was added in.
+
+The overhead of supporting this is so negligible that we'd prefer to make everyone
+happy, if at all possible.
+
+They all de-serialize to exactly the same data structure (and this is validated with unit tests),
+so you can use whichever of the formats you feel strongest about, or hate the least.
+
+Why Python 3.13?
+^^^^^^^^^^^^^^^^
+
+For completely selfish reasons such as:
+
+- Wanting to use the latest and greatest Python features
+- Not wanting to bother with multi version support
+
+Exosphere was written mostly to scratch the author's own itch.
+While it is made public in the hopes that it will be useful to others,
+and great care and effort has been spent on documentation and ease of use,
+the focus at this time remains to keep the author happy.
+
+Compatibility test matrices are unfortunately not a source of happiness.
+
+Platform Support
+----------------
+
 I really like the dashboard. Can I still use it if my systems are unsupported?
-------------------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Yes, as long as the remote system is a Unix-like operating system.
 
@@ -30,8 +76,85 @@ counts will be disabled, but this part will remain functional.
 If the system in question is not a Unix-like operating system, it will not
 be discoverable at all, and should not be added to the inventory.
 
+When managing Ubuntu systems, will this handle snaps?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Exosphere does not currently support snaps or flatpaks.
+There are no immediate plans to add support for these, but it is certainly possible
+in the future, if this becomes a common facet of server management.
+
+On BSD systems, will this handle system updates and source ports?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Exosphere does not currently support system updates or source ports.
+It only supports Binary Packages, for both FreeBSD and OpenBSD.
+
+There are plans to add support for system updates in the future, presenting
+them as a synthetic package in the updates view, but this needs more work.
+
+For the time being, cron reports and mailing lists for `syspatch` and
+`freebsd-update` are recommended to keep tabs on these.
+
+Does FreeBSD support extend to things like OPNSense?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since **1.3.4**, the ``pkg`` provider performs repository synchronization in a
+manner that is compatible with OPNSense, and the platform is supported
+as FreeBSD.
+
+As long as you configure sudo and sudoers correctly, and that the system
+uses ``pkg`` underneath, it should work just fine.
+
+Is Windows support planned or even possible?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The application runs fine on Windows, and while managing Windows is something we would love
+to implement, the connection methods are not incredibly straightforward, and the APIs and
+interfaces for update and patch management are not great. Microsoft continues to hope you
+will buy into their management tools, so the core APIs are not very accessible as a result.
+
+Windows support remains an eventual goal, but it is not currently planned.
+
+Configuration and Customization
+-------------------------------
+
+Can I specify a custom path for the configuration file?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Yes! You can specify a custom path for the configuration file by setting the
+``EXOSPHERE_CONFIG_FILE`` environment variable to the full path of the file you wish to use.
+
+See :doc:`configuration` for more details on other environment variables
+you can define to influence or override the configuration.
+
+I don't like the ascii art banner in interactive mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can disable it entirely with the ``no_banner``
+:ref:`config option <no_banner_option>`.
+
+Is there any way to disable the update check?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Yes, you can disable the update check by setting the ``update_checks``
+:ref:`config option <update_checks_option>` to ``false`` in the
+configuration file.
+
+This should be helpful in environments where you do not want to talk to
+PyPI at all.
+
+If you are a prospective package maintainer wishing to package Exosphere
+for your favorite platform's repositories, it is recommended that you patch
+out the default value of this option to ``False`` in ``exosphere/config.py``,
+or override via :ref:`environment variables <config_env_vars>`, if feasible.
+
+.. _faq-troubleshooting:
+
+Troubleshooting
+---------------
+
 Why does ping report Offline when the system is reachable?
-----------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``ping`` checks in exosphere aren't ICMP ping, but SSH pings.
 They will only return an Online status if the remote system can be
@@ -56,17 +179,8 @@ perform any of the other operations on it anyways.
 You can re-run the ``discovery`` command to find out what the issue is and
 correct it, if you are getting this during initial setup.
 
-Can I specify a custom path for the configuration file?
--------------------------------------------------------
-
-Yes! You can specify a custom path for the configuration file by setting the
-``EXOSPHERE_CONFIG_FILE`` environment variable to the full path of the file you wish to use.
-
-See :doc:`configuration` for more details on other environment variables
-you can define to influence or override the configuration.
-
 I get an error with "Private key file is encrypted", what does it mean?
------------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The presence of this error in logs means that authentication failed in some way.
 
@@ -76,7 +190,7 @@ Verify that:
 - Your SSH agent is running and has the correct key loaded
 - The right user name is being used to connect
 
-The unhelpful error message is unfortunately `Known Issue`_ in the `paramiko`
+The unhelpful error message is unfortunately a `Known Issue`_ in the `paramiko`
 library, which is used internally to handle SSH connections. Whenever
 authentication fails when an SSH agent is used, this is the exception
 that will be raised, regardless of the actual issue.
@@ -85,7 +199,7 @@ Exosphere will generally catch this specific error and rewrite the error message
 to be more helpful, but there are a few edge cases where it may be displayed as-is.
 
 My system using `dnf` or `yum` hangs when refreshing
-----------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The `dnf` and `yum` providers do a best effort to prevent interactive
 prompts when running the commands they need to synchronize repositories
@@ -114,7 +228,7 @@ And answer all the prompts that may appear. The provider should no longer hang
 past this point.
 
 After an update, my system using `dnf` fails to refresh!
---------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After certain types of updates, you may get the following error message when
 trying to refresh a `dnf` based system:
@@ -139,7 +253,7 @@ This should resolve the issue, and you should be able to refresh the system
 without write access errors afterwards.
 
 I've tuned the timeout but this one host keeps getting flagged offline
-----------------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Exosphere does use a fairly aggressive timeout value for its SSH connections,
 but if you have a host that is consistently supremely slow to respond, yet you
@@ -154,7 +268,7 @@ that host specifically by setting the ``connect_timeout``
 having to change the global option.
 
 The frequent SSH connections are causing issues on my SSH server
-----------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you have systems that have connection rate limiting, or take a while
 to authenticate, you can enable SSH connection pipelining to reduce
@@ -163,14 +277,49 @@ the amount of connection churn.
 See the :ref:`documentation on SSH Pipelining <ssh_pipelining_docs>` as
 well as the :ref:`ssh_pipelining configuration option <ssh_pipelining_option>`.
 
-I don't like the ascii art banner in interactive mode
------------------------------------------------------
+Updates refresh fails on my OpenBSD system with an exotic architecture!
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can disable it entirely with the ``no_banner``
-:ref:`config option <no_banner_option>`.
+Exosphere relies on the availability of the ``syspatch`` command to determine
+if the system is tracking a stable release or `-current`.
+
+If you're running a more exotic, non-x86 architecture, Exosphere may not
+be able to handle the failure mode gracefully, and we'd deeply appreciate
+it if you could `file a bug report`_ with the output of ``syspatch -l``
+so we can improve this situation.
+
+Help, the sudoers snippet I generated does not work!
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The usual checklist for files in sudoers.d applies here:
+
+- The file must be owned by root
+- Must have permissions of 0440
+- Must not contain syntax errors (check with ``visudo -c -f /etc/sudoers.d/yourfile``)
+
+If you are still having issues, a common problem is another rule matching last.
+Sudo reads rules in lexicographic order (i.e., not strictly alphabetical), but does not
+merge them, and the last matching rule wins.
+
+You can verify ordering with ``visudo -c`` and find out which rule is matching
+last with:
+
+.. code-block:: bash
+
+    sudo -l -U youruser /the/sudo/command --and --args
+
+and compare with the output of ``sudo -ll`` to see which rule matched vs which was expected.
+
+You can find which exact command exosphere is trying to run in the :doc:`providers`
+documentation.
+
+A quick workaround for ordering issues is to just name the generated snippet with a prefix
+that ensures it is loaded and matched last, for instance:
+
+``/etc/sudoers.d/zz-exosphere``
 
 After upgrading to 3.0, my old shell completion misbehaves
-----------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Exosphere can install tab-completion for **zsh**, **bash** and **fish** with:
 
@@ -194,7 +343,7 @@ To clean up the previous version's files:
   ``source`` line from ``~/.bashrc``.
 - **zsh**: delete ``~/.zfunc/_exosphere`` (the new script is installed under
   ``~/.zsh/completions``, or your oh-my-zsh completions directory).
-- **fish**: nothing to do — the new script overwrites the old one at the
+- **fish**: nothing to do --- the new script overwrites the old one at the
   same path.
 
 .. attention::
@@ -231,140 +380,6 @@ To clean up the previous version's files:
    ``Set-PSReadLineKeyHandler`` lines if other tools rely on them. Restart
    PowerShell afterwards.
 
-When managing Ubuntu systems, will this handle snaps?
------------------------------------------------------
-
-Exosphere does not currently support snaps or flatpaks.
-There are no immediate plans to add support for these, but it is certainly possible
-in the future, if this becomes a common facet of server management.
-
-On BSD systems, will this handle system updates and source ports?
------------------------------------------------------------------
-
-Exosphere does not currently support system updates or source ports.
-It only supports Binary Packages, for both FreeBSD and OpenBSD.
-
-There are plans to add support for system updates in the future, presenting
-them as a synthetic package in the updates view, but this needs more work.
-
-For the time being, cron reports and mailing lists for `syspatch` and
-`freebsd-update` are recommended to keep tabs on these.
-
-Does FreeBSD support extend to things like OPNSense?
------------------------------------------------------
-
-Since **1.3.4**, the ``pkg`` provider performs repository synchronization in a
-manner that is compatible with OPNSense, and the platform is supported
-as FreeBSD.
-
-As long as you configure sudo and sudoers correctly, and that the system
-uses ``pkg`` underneath, it should work just fine.
-
-Updates refresh fails on my OpenBSD system with an exotic architecture!
------------------------------------------------------------------------
-
-Exosphere relies on the availability of the ``syspatch`` command to determine
-if the system is tracking a stable release or `-current`.
-
-If you're running a more exotic, non-x86 architecture, Exosphere may not
-be able to handle the failure mode gracefully, and we'd deeply appreciate
-it if you could `file a bug report`_ with the output of ``syspatch -l``
-so we can improve this situation.
-
-Help, the sudoers snippet I generated does not work!
-----------------------------------------------------
-
-The usual checklist for files in sudoers.d applies here:
-
-- The file must be owned by root
-- Must have permissions of 0440
-- Must not contain syntax errors (check with `visudo -c -f /etc/sudoers.d/yourfile`)
-
-If you are still having issues, a common problem is another rule matching last.
-Sudo reads rules in lexicographic order (i.e., not strictly alphabetical), but does not
-merge them, and the last matching rule wins.
-
-You can verify ordering with `visudo -c` and find out which rule is matching
-last with:
-
-.. code-block:: bash
-
-    sudo -l -U youruser /the/sudo/command --and --args
-
-and compare with the output of ``sudo -ll`` to see which rule matched vs which was expected.
-
-You can find which exact command exosphere is trying to run in the :doc:`providers`
-documentation.
-
-A quick workaround for ordering issues is to just name the generated snippet with a prefix
-that ensures it is loaded and matched last, for instance:
-
-``/etc/sudoers.d/zz-exosphere``
-
-Is there any way to disable the update check?
----------------------------------------------
-
-Yes, you can disable the update check by setting the ``update_checks``
-:ref:`config option <update_checks_option>` to ``false`` in the
-configuration file.
-
-This should be helpful in environments where you do not want to talk to
-PyPI at all.
-
-If you are a prospective package maintainer wishing to package Exosphere
-for your favorite platform's repositories, it is recommended that you patch
-out the default value of this option to ``False`` in ``exosphere/config.py``,
-or override via :ref:`environment variables <config_env_vars>`, if feasible.
-
-Is Windows support planned or even possible?
-------------------------------------------------
-
-The application runs fine on Windows, and while managing Windows is something we would love
-to implement, the connection methods are not incredibly straightforward, and the APIs and
-interfaces for update and patch management are not great. Microsoft continues to hope you
-will buy into their management tools, so the core APIs are not very accessible as a result.
-
-Windows support remains an eventual goal, but it is not currently planned.
-
-Why all the different config file formats?
-------------------------------------------
-
-The author is fond of yaml, but recognizes toml is gaining traction in the Python community.
-At this point also supporting json was so low effort that it was added in.
-
-The overhead of supporting this is so negligible that we'd prefer to make everyone
-happy, if at all possible.
-
-They all de-serialize to exactly the same data structure (and this is validated with unit tests),
-so you can use whichever of the formats you feel strongest about, or hate the least.
-
-Didn't Exosphere used to have a Web UI? What happened to it?
-------------------------------------------------------------
-
-It was removed in version 3.0. The Web UI started as a neat curiosity more than
-a feature, but never left the experimental stage.
-
-It was always provided as a separate, opt-in, extra for the python packages,
-and installed and used by few, least of all the author.
-
-As the project matured, and new features started clashing with the way it was
-implemented, it became clear it should be removed instead of being left to rot
-in its current, janky, underdeveloped state.
-
-Why Python 3.13?
-----------------
-
-For completely selfish reasons such as:
-
-- Wanting to use the latest and greatest Python features
-- Not wanting to bother with multi version support
-
-Exosphere was written mostly to scratch the author's own itch.
-While it is made public in the hopes that it will be useful to others,
-and great care and effort has been spent on documentation and ease of use,
-the focus at this time remains to keep the author happy.
-
-Compatibility test matrices are unfortunately not a source of happiness.
 
 .. _UnattendedUpgrades: https://wiki.debian.org/UnattendedUpgrades
 .. _Ansible: https://www.ansible.com/

--- a/docs/source/gettinghelp.rst
+++ b/docs/source/gettinghelp.rst
@@ -1,0 +1,62 @@
+Getting Help
+============
+
+While exosphere is provided as-is, with no expectation of warranty or support,
+there are a few resources available for help if you run into issues or have questions.
+
+Before reaching out
+-------------------
+
+Common issues are already covered in the following places:
+
+* The :doc:`troubleshooting` walks through diagnosing the common failures.
+* The :ref:`FAQ <faq-troubleshooting>` collects specific symptoms and their fixes.
+
+It is worth a quick pass through both --- the answer is often there, and if it
+is not, the steps you already tried are exactly what helps someone help you.
+
+Asking a question
+-----------------
+
+For usage questions, "how do I...", ideas, or just to share what you have built,
+use `GitHub Discussions`_. This is the best place for anything that is not
+clearly a bug.
+
+Reporting a bug
+---------------
+
+If you have found a bug, please open an issue using the `bug report form`_.
+
+To make it actionable, include as much of the following as you can:
+
+* **The Exosphere version** you are running:
+
+  .. code-block:: console
+
+      $ exosphere version check
+
+* **Your platform**: the operating system you run Exosphere on, and the
+  remote platform(s) involved.
+* **Relevant log output**: Reproduce the problem with
+  :ref:`log_level <log_level_option>` set to ``DEBUG``, then attach the relevant
+  portion of the log file (find it via ``exosphere config paths``).
+* **A sanitized configuration snippet**, or the output of ``exosphere config diff``,
+  so the relevant options are visible. Remove anything sensitive first.
+* **Steps to reproduce**, along with what you expected versus what actually
+  happened.
+
+For problems with updates or repository sync on a specific platform, the
+:doc:`providers` page lists the exact commands Exosphere runs --- running the
+failing one by hand on the remote host and including its output is incredibly
+helpful.
+
+Feature requests and ideas
+--------------------------
+
+Suggestions are welcome. Open a discussion on `GitHub Discussions`_, or an issue
+via the `bug report form`_ --- whichever feels more appropriate. If you have
+built something neat on top of Exosphere's :doc:`reporting` (a dashboard, a bot,
+a coffee-brewing cron job), we would love to hear about it.
+
+.. _GitHub Discussions: https://github.com/mrdaemon/exosphere/discussions
+.. _bug report form: https://github.com/mrdaemon/exosphere/issues/new/choose

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,5 +1,5 @@
-Glossary and Reference
-======================
+Glossary and Common Terms
+=========================
 
 This section defines common terms and concepts used within Exosphere.
 
@@ -45,10 +45,11 @@ Discovery
     change, such as a new OS version or package manager change.
 
 Refresh
-    A Refresh is the process of querying the host for its current available updates.
-    This is generally done by querying the package manager. The process is universally
-    read-only, and does not perform any system changes, aside from affecting some
-    metadata timestamps and caches on certain platforms and operating systems.
+    A Refresh is the process of querying the host for its current available updates
+    and general state. This is generally done by querying the package manager.
+    The process is universally read-only, and does not perform any system changes,
+    aside from affecting some metadata timestamps and caches on certain platforms
+    and operating systems.
 
     This is usually separate from a Repository Sync, but often can be combined
     into a single operation depending on context.
@@ -56,8 +57,8 @@ Refresh
 Repositories
     Repositories is the generic term for the authoritative list of packages on the
     host platform. For instance, on Debian and Ubuntu systems, it refers
-    to the remote systems configured in `/etc/apt/sources.list` and friends.
-    On RedHat-likes, it refers to the repositories configured in `/etc/yum.repos.d/`,
+    to the remote systems configured in ``/etc/apt/sources.list`` and friends.
+    On RedHat-likes, it refers to the repositories configured in ``/etc/yum.repos.d/``,
     and so on.
 
 Repository Sync
@@ -65,10 +66,10 @@ Repository Sync
     from these remote servers, so that the next update check will have the latest
     information.
 
-    This is equivalent to running `apt-get update` on Debian-based systems,
-    or `dnf makecache` on RedHat-based systems.
+    This is equivalent to running ``apt-get update`` on Debian-based systems,
+    or ``dnf makecache`` on RedHat-based systems.
 
     This process is generally safe and read-only, but on systems where
-    sudo is required, it may update repository metadata system wide.
+    ``sudo`` is required, it may update repository metadata system wide.
     This is generally not an issue, but if it is problematic, rest assured
     that the behavior is entirely opt-in, in these cases.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,25 +49,49 @@ with the :doc:`quickstart` to get an overview of how to use Exosphere.
 
 .. toctree::
    :maxdepth: 2
-   :caption: User Documentation:
+   :caption: Getting Started
 
+   concepts
    installation
    quickstart
    supportedos
-   connections
-   configuration
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Using Exosphere
+
    cli
    ui
    reporting
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Administration
+
+   connections
+   configuration
+   sudo
    cachefile
-   providers
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Support
+
+   troubleshooting
    faq
+   gettinghelp
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   providers
    command_reference
    glossary
 
 .. toctree::
    :maxdepth: 2
-   :caption: API Documentation:
+   :caption: Developer Documentation
 
    api/index
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -73,13 +73,17 @@ You can also explore the interactive help system in the CLI by running:
 This will detect the platform and package manager for each host.
 It only needs to be done once, or if something changes on the host.
 
-**Refresh Updates**
+If you encounter issues at this step, see the :doc:`connections`
+and :doc:`supportedos` pages for more details.
+
+**Refresh Hosts**
 
 .. code-block:: exosphere
 
     exosphere> inventory refresh
 
-This will retrieve the available updates and patches for each host.
+This will refresh the state of each host and collect information about
+available updates.
 
 **View Status and Host Details**
 
@@ -93,6 +97,8 @@ updates all in one place.
 
 Next Steps
 ----------
+
+For more fundamental details, you could have a look at :doc:`concepts`.
 
 To go further, you can:
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -35,6 +35,7 @@ keybind
 keybinds
 kwargs
 libc
+lifecycle
 linux
 lstrip
 macOS

--- a/docs/source/sudo.rst
+++ b/docs/source/sudo.rst
@@ -1,0 +1,178 @@
+Sudo Policies and Privileges
+============================
+
+Exosphere and its provider modules try, as much as possible, to avoid requiring elevated
+privileges at all. Unfortunately, on some platforms, some operations that we rely on
+do require them.
+
+This section describes how to configure the Sudo Policy for Exosphere as well
+as optionally grant the required privileges on the remote hosts.
+
+.. admonition:: Note
+
+    These instructions below are entirely optional, and you can absolutely use
+    Exosphere without ever setting up sudoers configuration or privileges.
+    You will just be limited to the operations that do not require
+    elevated privileges, which is the majority of them.
+
+Enumerating Providers and their Privileges
+------------------------------------------
+
+The documentation for :doc:`providers` includes details, but you can query this via the
+exosphere CLI and its ``sudo`` command. Here is an example below:
+
+.. code-block:: console
+
+    $ exosphere sudo providers
+                                    Providers Requirements
+    ┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
+    ┃ Provider ┃ Platform                       ┃ Sync Repositories ┃ Refresh Updates ┃
+    ┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
+    │ Apt      │ Debian/Ubuntu Derivatives      │ Requires Sudo     │ No Privileges   │
+    │ Pkg      │ FreeBSD                        │ Requires Sudo     │ No Privileges   │
+    │ PkgAdd   │ OpenBSD                        │ No Privileges     │ No Privileges   │
+    │ Dnf      │ Fedora/RHEL/CentOS Derivatives │ No Privileges     │ No Privileges   │
+    │ Yum      │ RHEL/CentOS 7 and earlier      │ No Privileges     │ No Privileges   │
+    └──────────┴────────────────────────────────┴───────────────────┴─────────────────┘
+
+For instance, we can see here that the ``Apt`` and ``Pkg`` providers require sudo privileges
+to sync repositories, but do not require any privileges to refresh updates.
+
+.. note::
+   The table above shows the privilege requirements for each operation type:
+
+   * **Sync Repositories**: Updating package repository metadata (e.g., ``apt-get update``)
+   * **Refresh Updates**: Checking for available package updates
+
+Configuring Sudo Policies
+-------------------------
+
+There are currently two valid settings for the Sudo Policy options:
+
+* ``skip``: Do not use sudo at all, skip operations that require it and emit a warning in logs
+* ``nopasswd``: Assume sudoers configuration allows running the provider commands without a password
+
+The default Sudo Policy for exosphere is `skip`, :ref:`configured globally <default_sudo_policy_option>`.
+This means that Exosphere will not attempt to use sudo at all when running provider commands.
+
+This can also be configured per system, by setting the :ref:`sudo policy option <hosts_sudo_policy_option>`
+at the host level.
+
+If you want to be able to use Exosphere to run operations that require sudo privileges, you will
+need to configure sudoers on the remote host(s) where this applies to allow them to be run without
+a password.
+
+.. attention::
+
+    This can potentially expose your system to security risks if not configured properly.
+    See the section below for details on how to configure this safely.
+
+Generating a Sudoers configuration
+----------------------------------
+
+You can manually configure sudoers with ``NOPASSWD:`` as you wish, so long as it allows
+the commands specified in the :doc:`providers` documentation to run.
+
+However, since this can be a combination of tedious, risky and error-prone,
+Exosphere provides a helper command that will generate a sudoers snippet for you,
+for any host, or specific provider, while also allowing you to specify a username.
+
+To generate a sudoers configuration snippet for the ``Apt`` provider, for instance,
+with the username ``bigadmin``, you can run the following command:
+
+.. code-block:: console
+
+    $ exosphere sudo generate --provider apt --user bigadmin
+    # Generated for Debian/Ubuntu Derivatives
+    Cmnd_Alias EXOSPHERE_CMDS = /usr/bin/apt-get update
+    bigadmin ALL=(root) NOPASSWD: EXOSPHERE_CMDS
+
+You can then take this output and drop it in a file on the remote host, such as
+``/etc/sudoers.d/zz-exosphere`` (or, if on a FreeBSD System,
+``/usr/local/etc/sudoers.d/zz-exosphere``) and then switch the Sudo Policy to
+``nopasswd`` for that host.
+
+.. admonition:: On usernames
+
+    The username parameter is optional. If you do not specify it, the command will
+    try to use, in this order:
+
+    1. The username configured for the host, if any (when using ``--host``)
+    2. The username configured in the global configuration, if any
+    3. The current local username running the exosphere command
+
+You can also use the ``--host`` option to automatically detect the provider
+for a host and generate the appropriate sudoers snippet for it.
+
+For more details, see ``exosphere sudo generate --help``.
+
+Security Considerations
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The generated sudoers configuration is designed to be as secure as possible:
+
+* **Specific commands only**: Only the exact commands needed by the provider are allowed
+* **Absolute paths**: Commands use full absolute paths (e.g., ``/usr/bin/apt-get``)
+* **Root user only**: Commands are restricted to run as ``root`` (not ``ALL``)
+* **No password required**: Uses ``NOPASSWD:`` to avoid credential storage/prompting
+* **Command aliases**: Uses ``Cmnd_Alias`` for better maintainability
+
+This approach is significantly more secure than granting broad sudo access, as it:
+
+* Limits the attack surface to specific commands that are known in advance
+* Prevents privilege escalation beyond the intended operations
+* Avoids the security risks of password-based authentication
+
+Alternatives
+^^^^^^^^^^^^
+
+If your relevant providers only require sudo privileges for repository synchronization,
+and you prefer not to use the sudoers configuration, you can still
+configure your remote systems to sync those repositories on a schedule.
+You will just not be able to use Exosphere to do it on-demand, but the
+repository contents should always be reasonably up to date.
+
+On Debian/Ubuntu systems, consider these options:
+
+* The `unattended-upgrades`_ package, which can be configured to automatically
+  run ``apt-get update`` and optionally ``apt-get upgrade`` on a schedule
+* The ``apt-config-auto-update`` package for simpler automatic update configuration
+* Custom cron jobs with ``apt-get update`` if you prefer manual control
+
+On FreeBSD, you can set up a cron job or periodic task to run
+``/usr/sbin/pkg update`` regularly.
+
+For other distributions, similar automated package management tools are available.
+
+How can I check what the effective Sudo Policy is for a given host?
+-------------------------------------------------------------------
+
+You can use the ``sudo check`` helper command.
+
+As an example, to check the effective Sudo Policy for a host named ``bigserver``:
+
+.. code-block:: console
+
+    $ exosphere sudo check bigserver
+    Sudo Policy for bigserver
+
+     Global Policy:          skip
+     Host Policy:            nopasswd (local)
+     Package Manager:        apt
+
+     Can Sync Repositories:  Yes
+     Can Refresh Updates:    Yes
+
+This will tell you what the effective Sudo Policy is for that host, as well as
+where that is configured. For instance, in the example above, you can see the
+global policy is ``skip``, but the host policy has been set to ``nopasswd``
+locally, in the inventory host options.
+
+The global Sudo Policy can also be displayed via:
+
+.. code-block:: console
+
+    $ exosphere sudo policy
+    Global SudoPolicy: skip
+
+.. _unattended-upgrades: https://wiki.debian.org/UnattendedUpgrades

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -61,7 +61,8 @@ Compatibility List
 - Other Unix-like systems (e.g., Solaris, AIX, IRIX, Mac OS)
 
 The bar for entry is fairly low to fit this description, as long as it can be connected
-to via SSH and returns something useful via ``uname -s``, it will work here.
+to via SSH, has a POSIX shell available [#binsh]_ and returns something useful via
+``uname -s``, it will work here.
 
 ❌ Exosphere explicitly **does not support** the following platforms:
 
@@ -95,7 +96,7 @@ entirely through SSH connections and standard system utilities.
 **Optional Requirements**
 
 - **Elevated privileges** for certain operations on some platforms (i.e. `root`)
-- ``sudo`` installed on the remote host (if needed) and :ref:`configured properly <sudo-policies-and-privileges>`
+- ``sudo`` installed on the remote host (if needed) and :doc:`configured properly <sudo>`
 
 See below for more details.
 
@@ -107,7 +108,8 @@ See below for more details.
 Some providers may require elevated privileges to perform certain operations, but this is
 entirely optional.
 
-More details about all of this are available in the :doc:`connections` section.
+More details about all of this are available in the :doc:`connections` and
+:doc:`sudo` sections.
 
 .. note::
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,0 +1,181 @@
+Troubleshooting Guide
+=====================
+
+When something is not working as expected, this guide walks through how to
+diagnose the problem, starting from the tools Exosphere gives you and working
+toward the most common causes.
+
+For specific symptoms and their fixes, see the :ref:`FAQ <faq-troubleshooting>`.
+If you work through both and are still stuck, :doc:`gettinghelp` points you at the
+right place to ask, or submit a bug report.
+
+Check the logs
+--------------
+
+Exosphere always writes a log file, regardless of how you run it, and it is the
+first place to look. To find it, run:
+
+.. code-block:: console
+
+    $ exosphere config paths
+
+and look under the ``Log:`` entry for the path on your platform.
+
+If you are in the :doc:`TUI <ui>`, you can also press ``l`` to open the Logs
+screen and watch events as they happen.
+
+Turn up the verbosity
+---------------------
+
+By default, Exosphere logs at ``INFO`` level. If the logs do not explain the
+problem, raise it to ``DEBUG`` via the :ref:`log_level <log_level_option>`
+option:
+
+.. tabs::
+
+    .. group-tab:: YAML
+
+        .. code-block:: yaml
+
+            options:
+              log_level: DEBUG
+
+    .. group-tab:: TOML
+
+        .. code-block:: toml
+
+            [options]
+            log_level = "DEBUG"
+
+    .. group-tab:: JSON
+
+        .. code-block:: json
+
+            {
+                "options": {
+                    "log_level": "DEBUG"
+                }
+            }
+
+You can also raise it for a single run, without editing your config, via the
+``EXOSPHERE_OPTIONS_LOG_LEVEL`` :ref:`environment variable <config_env_vars>`.
+
+.. tabs::
+
+    .. group-tab:: Unix/macOS
+
+        .. code-block:: console
+
+            $ EXOSPHERE_OPTIONS_LOG_LEVEL=DEBUG exosphere
+
+    .. group-tab:: Windows/PowerShell
+
+        .. code-block:: powershell
+
+            $env:EXOSPHERE_OPTIONS_LOG_LEVEL = "DEBUG"
+            exosphere
+
+    .. group-tab:: Windows/cmd
+
+        .. code-block:: batch
+
+            set EXOSPHERE_OPTIONS_LOG_LEVEL=DEBUG
+            exosphere
+
+You can confirm this worked by checking the output of ``exosphere config source``
+and ``exosphere config diff``.
+
+For library-level detail (the SSH internals from Fabric and paramiko, for
+instance), there is the :ref:`debug <debug_option>` option, but be warned that
+it is extremely noisy and is rarely needed outside of development. We suggest not
+using this unless asked in a bug report.
+
+Check the configuration Exosphere actually loaded
+-------------------------------------------------
+
+A surprising number of "it is not doing what I told it to" problems come down to
+Exosphere loading a different configuration file than you expect, or an
+environment variable quietly overriding a value.
+
+Confirm what was loaded, and from where:
+
+.. code-block:: console
+
+    $ exosphere config source
+
+This shows the active configuration file path and any environment variables
+influencing the configuration. To inspect the effective values, use
+``config show``, or ``config diff`` to see only what differs from the defaults.
+
+Test connectivity
+-----------------
+
+Most failures are connectivity or authentication problems. The quickest test is
+a discovery, which prints a clear table of any errors:
+
+.. code-block:: exosphere
+
+    exosphere> inventory discover
+
+or, for a single host:
+
+.. code-block:: exosphere
+
+    exosphere> host discover bigserver
+
+If a host fails, work through the checklist:
+
+* Your SSH agent is running and has the right key loaded
+* The username and port are correct (see :doc:`configuration`)
+* The host is reachable and its SSH service is running
+* The host allows public key authentication
+
+To reproduce the connection outside of Exosphere, with full detail:
+
+.. code-block:: console
+
+    $ ssh -vvv bigserver
+
+Remember that Exosphere honors ``~/.ssh/config`` and ``/etc/ssh/ssh_config``, so
+double-check any host aliases or per-host settings there. The :doc:`connections`
+page covers all of this in depth.
+
+.. tip::
+
+    A host shown as **Offline** is not an ICMP ping failure --- Exosphere
+    considers a host online only if it can open an SSH session and run a trivial
+    command. We consider "Online" to mean in a state where it could execute further
+    commands and queries, which implies end-to-end ssh connectivity.
+
+Common situations
+-----------------
+
+A few recurring issues, with where to look:
+
+* **A host is flagged Offline but you can reach it** --- usually slow DNS on the
+  remote ``sshd``; the :ref:`FAQ <faq-troubleshooting>` covers the ``UseDNS no`` fix and the per-host
+  :ref:`connect_timeout <connect_timeout_host_option>` option.
+* **"Private key file is encrypted"** --- an authentication failure in disguise;
+  the :ref:`FAQ <faq-troubleshooting>` explains the underlying cause.
+* **A** ``dnf`` **or** ``yum`` **host hangs or errors on refresh** --- the
+  :ref:`FAQ <faq-troubleshooting>` has the manual ``makecache`` workaround and the read-only database
+  fix.
+* **Frequent connections upset your SSH server** --- enable
+  :ref:`SSH pipelining <ssh_pipelining_docs>` to cut down on connection churn.
+* **A generated sudoers snippet does not work** --- the :ref:`FAQ <faq-troubleshooting>` has the
+  ownership, permissions, and rule-ordering checklist.
+
+When to look at the providers
+-----------------------------
+
+If a host connects fine but updates or repository sync misbehave, the cause is
+often specific to the package manager. The :doc:`providers` page documents the
+exact commands each provider runs, along with platform quirks --- running the
+failing command by hand on the remote host is often the fastest way to see what
+is really going wrong.
+
+Still stuck?
+------------
+
+If you have worked through this guide and the :ref:`FAQ <faq-troubleshooting>` without luck, head to
+:doc:`gettinghelp` for where to ask and how to file a useful bug report.


### PR DESCRIPTION
Editing and organization pass on the Documentation to correspond with version 3.0.0 releasing imminently.

* Add a new Concepts ("How Exosphere Works") chapter as an introduction, accompanied by neat diagrams to illustrate the lifecycle of Exosphere and its components.
* TOC has been reorganized and split into subsections to make it easier to follow, each following a new Arc:
  - Getting Started
  - Using Exosphere
  - Administration
  - Support
  - Reference
  - Developer Documentation
* Connections document has been renamed to "Connections and Authentication" to better reflect its content.
* Sudo Policies section has been split off from the same into its own document and chapter.
* FAQ has been reorganized to be split into subsections, as it was getting unwieldy and hard to navigate. This will also help a potential user home in on the troubleshooting entries without having to suffer through "What are the Author's Favorite Underpants" first.
* Add new Troubleshooting chapter to help users diagnose and resolve issues, linking to the FAQ section. Explains how to logs etc.
* Add new Getting Help chapter to explain how to get help, and how to report issues.
* Misc wording, formatting and visual cleanups where caught.

This brings the documentation to a state much closer to how I hoped it would be when I released 1.0.