### PR TITLE
Reporting: Add schema export and status commands

### DIFF
--- a/docs/source/reporting.rst
+++ b/docs/source/reporting.rst
@@ -193,6 +193,30 @@ remains consistent across all output types.
     For detailed information about all available options and flags,
     see :doc:`command_reference` or run ``exosphere report generate --help``.
 
+Status Summary
+--------------
+
+For a quick, at-a-glance overview rather than a full report, ``report status``
+prints a condensed, plain-text summary of the entire inventory:
+
+.. code-block:: console
+
+    $ exosphere report status
+    15 of 25 hosts have pending updates, 10 with security updates
+    2 hosts have a pending reboot.
+    1 host has stale data, consider running a refresh.
+
+The reboot and stale lines only appear when there is something to report, and
+when nothing is pending the summary simply reads ``All hosts are up to date.``.
+Hosts that have not yet been discovered contribute nothing to the counts, as
+they have no known state.
+
+Like the rest of the reporting commands, this operates entirely from the cache
+and requires no connectivity. Color is automatically dropped when the output is
+not a terminal, which makes it well suited to non-interactive uses, such as
+redirecting it into a MOTD or similar through a user cronjob, timer, or periodic
+task.
+
 .. _json-schema:
 
 JSON Schema Details
@@ -214,6 +238,15 @@ but is also made available here, corresponding to the version this documentation
 for:
 
 :download:`host-report.schema.json <_static/host-report.schema.json>` as of |CurrentVersionTag|
+
+You can also emit the schema for your installed version directly from the CLI with
+``report schema`` (printed to stdout, or written to a file with ``--output``), which is
+handy for validating or integrating with the JSON output offline.
+
+.. code-block:: console
+
+    $ exosphere report schema --output host-report.schema.json
+
 
 Structure Overview
 ^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev19"
+version = "3.0.0.dev20"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -2,6 +2,7 @@
 Reporting command module
 """
 
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -18,6 +19,7 @@ from exosphere.commands.utils import (
 )
 from exosphere.inventory import FilterMode
 from exosphere.reporting import OutputFormat, ReportRenderer, ReportScope, ReportType
+from exosphere.schema import get_host_report_schema
 
 ROOT_HELP = """
 Reporting Commands
@@ -221,5 +223,125 @@ def generate(
             # Rich will write to stderr anyways to notify of the error,
             # this just prevents the humongous backtrace.
             pass
+
+    return 0
+
+
+@app.command
+def schema(
+    output: Annotated[
+        Path | None,
+        Parameter(
+            name=["--output", "-o"],
+            validator=validators.Path(dir_okay=False),
+        ),
+    ] = None,
+) -> int:
+    """
+    Show or write the JSON Schema for the current version of Exosphere
+
+    Emits the JSON Schema (draft-07) describing the structure produced
+    by `report generate --format json`, for the currently running
+    version of Exosphere.
+
+    This allows anyone to easily get an overview of the structure,
+    validate and integrate, offline, without a local source tree or
+    access to the online documentation.
+
+    By default the schema is printed to stdout. Use `--output` to
+    write it to a file instead.
+
+    Parameters
+    ----------
+    output
+        Write the schema to a file (defaults to stdout)
+    """
+    try:
+        schema_data = get_host_report_schema()
+    except (FileNotFoundError, ValueError) as e:
+        err_console.print(f"[red]Failed to load JSON schema: {e}[/red]")
+        return 2  # Application error
+
+    content = json.dumps(schema_data, indent=2)
+
+    if output:
+        try:
+            output.write_text(content, encoding="utf-8")
+        except Exception as e:
+            err_console.print(f"[red]Failed to write to {output}: {e}[/red]")
+            return 2  # Application error
+
+        err_console.print(f"JSON schema saved to [green]{output}[/green].")
+        return 0
+
+    try:
+        console.print(JSON(content))
+    except (BrokenPipeError, OSError):
+        # See note in `generate` about Windows broken pipe behavior.
+        pass
+
+    return 0
+
+
+@app.command
+def status() -> int:
+    """
+    Show a brief, condensed status summary of the inventory.
+
+    Prints a short, executive-summary overview of the whole inventory: how
+    many hosts have pending updates (and how many of those include security
+    updates), how many are awaiting a reboot, and whether any host data has
+    gone stale.
+
+    The output is plain and compact, suitable as an at-a-glance overview or
+    for inclusion in a system MOTD (e.g. by redirecting it to a file).
+
+    Color is automatically dropped when the output is not a terminal.
+
+    Hosts that have not yet been discovered contribute nothing to the update
+    and reboot counts, as they have no known state.
+    """
+    inventory = get_inventory()
+    hosts = list(inventory.hosts)
+
+    total = len(hosts)
+    if total == 0:
+        console.print("No hosts in inventory.")
+        return 0
+
+    def plural(n: int) -> str:
+        return "host" if n == 1 else "hosts"
+
+    def have(n: int) -> str:
+        return "has" if n == 1 else "have"
+
+    with_updates = [h for h in hosts if h.updates]
+    with_security = [h for h in hosts if h.security_updates]
+    needing_reboot = [h for h in hosts if h.needs_reboot]
+    stale = [h for h in hosts if h.is_stale]
+
+    if with_updates:
+        security_note = (
+            f", [red]{len(with_security)}[/red] with security updates"
+            if with_security
+            else ""
+        )
+        console.print(
+            f"[yellow]{len(with_updates)}[/yellow] of {total} {plural(total)} "
+            f"have pending updates{security_note}"
+        )
+    else:
+        console.print("[green]All hosts are up to date.[/green]")
+
+    if needing_reboot:
+        n = len(needing_reboot)
+        console.print(f"[red]{n}[/red] {plural(n)} {have(n)} a pending reboot.")
+
+    if stale:
+        n = len(stale)
+        console.print(
+            f"[dim]{n} {plural(n)} {have(n)} stale data, consider running a "
+            f"refresh.[/dim]"
+        )
 
     return 0

--- a/tests/commands/test_report.py
+++ b/tests/commands/test_report.py
@@ -2,6 +2,9 @@
 Tests for the report command module.
 """
 
+import json
+from datetime import datetime, timezone
+
 import pytest
 
 from exosphere.commands import report
@@ -10,6 +13,7 @@ from exosphere.data import Update
 from exosphere.inventory import Inventory
 from exosphere.objects import Host
 from exosphere.reporting import ReportScope, ReportType
+from exosphere.schema import get_host_report_schema
 
 
 @pytest.fixture(autouse=True)
@@ -118,6 +122,26 @@ def mock_get_hosts(mocker):
         )
 
     return _patch_hosts
+
+
+def _status_host(
+    name: str,
+    updates: list[Update] | None = None,
+    needs_reboot: bool | None = None,
+    stale: bool = False,
+    supported: bool = True,
+) -> Host:
+    """Build a Host with controlled state for status summary tests."""
+    host = Host(name=name, ip="10.0.0.1")
+    host.supported = supported
+    host.os = "linux"
+    host.package_manager = "apt"
+    host.updates = updates or []
+    host.needs_reboot = needs_reboot
+
+    host.last_refresh = None if stale else datetime.now(timezone.utc)
+
+    return host
 
 
 class TestGenerateCommand:
@@ -499,3 +523,92 @@ class TestGenerateCommand:
 
         assert exc_info.value.code == 1
         assert "Mutually exclusive arguments" in capsys.readouterr().err
+
+
+class TestSchemaCommand:
+    """Tests for the report schema command."""
+
+    def test_schema_to_stdout(self, capsys):
+        """Schema is printed to stdout as valid JSON matching the canonical schema."""
+        code = report.app(["schema"], result_action="return_value")
+        assert code == 0
+
+        # Rich pretty-prints the JSON; reparsing confirms validity and identity.
+        data = json.loads(capsys.readouterr().out)
+        assert data == get_host_report_schema()
+
+    def test_schema_to_file(self, tmp_path):
+        """--output writes the schema verbatim to a file."""
+        target = tmp_path / "host-report.schema.json"
+
+        code = report.app(
+            ["schema", "--output", str(target)], result_action="return_value"
+        )
+        assert code == 0
+
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert data == get_host_report_schema()
+
+    def test_schema_load_failure(self, mocker, capsys):
+        """A schema load error surfaces as an application error (exit 2)."""
+        mocker.patch(
+            "exosphere.commands.report.get_host_report_schema",
+            side_effect=FileNotFoundError("Oops everything broke"),
+        )
+
+        code = report.app(["schema"], result_action="return_value")
+        assert code == 2
+        assert "Failed to load JSON schema" in capsys.readouterr().err
+
+
+class TestStatusCommand:
+    """Tests for the report status command."""
+
+    def test_empty_inventory(self, mock_inventory, capsys):
+        """An empty inventory reports as such and exits cleanly."""
+        mock_inventory.hosts = []
+
+        code = report.app(["status"], result_action="return_value")
+        assert code == 0
+        assert "No hosts in inventory." in capsys.readouterr().out
+
+    def test_all_up_to_date(self, mock_inventory, capsys):
+        """With no pending updates, the summary states everything is current."""
+        mock_inventory.hosts = [_status_host("a"), _status_host("b")]
+
+        code = report.app(["status"], result_action="return_value")
+        assert code == 0
+
+        out = capsys.readouterr().out
+        assert "All hosts are up to date." in out
+
+    def test_pending_updates_and_security(self, mock_inventory, capsys):
+        """Update counts and security host count are summarized."""
+        sec = Update(name="curl", current_version="1", new_version="2", security=True)
+        reg = Update(name="vim", current_version="1", new_version="2", security=False)
+        mock_inventory.hosts = [
+            _status_host("a", updates=[sec, reg]),
+            _status_host("b", updates=[reg]),
+            _status_host("c"),
+        ]
+
+        code = report.app(["status"], result_action="return_value")
+        assert code == 0
+
+        out = capsys.readouterr().out
+        assert "2 of 3 hosts have pending updates" in out
+        assert "1 with security updates" in out
+
+    def test_reboot_and_stale_lines(self, mock_inventory, capsys):
+        """Pending reboot and stale data each produce their own line."""
+        mock_inventory.hosts = [
+            _status_host("a", needs_reboot=True),
+            _status_host("b", stale=True),
+        ]
+
+        code = report.app(["status"], result_action="return_value")
+        assert code == 0
+
+        out = capsys.readouterr().out
+        assert "1 host has a pending reboot." in out
+        assert "1 host has stale data" in out

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev19"
+version = "3.0.0.dev20"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Add two commands to the 'report' command group:

* `report schema` - outputs the JSON schema for the current report data structure, useful for validation and integration with other tools, and can be done entirely offline without access to the source tree or online documentation
* `report status` - outputs a simple (3-4 lines) summary of the state of the inventory, update counts, pending reboots, staleness etc. Intended to be an executive summary style view, or dropped into a motd or similar.

Test suite has been updated to cover the new commands, and documentation refreshed to cover the features.