### PR TITLE
Core: Cleanup task dispatch for unsupported hosts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0.dev20"
+version = "3.0.0.dev21"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -174,25 +174,19 @@ def refresh(
         )
         console.print() if verbose else None
 
-    # Unsupported hosts can't sync or refresh, partition them off
-    # This is handed to the task runner which will handle display
-    runnable = [host for host in hosts if host.supported]
-    skipped = [host for host in hosts if not host.supported]
-
     # If sync is requested, we will run the sync_repos task
     # Same as discovery, simple spinner
     if sync:
         console.print("[dim]Repository Sync:[/dim]") if verbose else None
         run_task_with_progress(
             inventory=inventory,
-            hosts=runnable,
+            hosts=hosts,
             operation=HostOperation.SYNC,
             task_description="Syncing package repositories",
             display_hosts=verbose,
             collect_errors=False,
             immediate_error_display=True,
             progress_args=SPINNER_PROGRESS_ARGS,
-            skipped=skipped,
         )
         console.print() if verbose else None
 
@@ -201,13 +195,12 @@ def refresh(
     console.print("[dim]Updates Refresh:[/dim]") if verbose else None
     errors = run_task_with_progress(
         inventory=inventory,
-        hosts=runnable,
+        hosts=hosts,
         operation=HostOperation.REFRESH,
         task_description="Refreshing package updates",
         display_hosts=verbose,
         collect_errors=True,
         immediate_error_display=False,
-        skipped=skipped,
     )
 
     errors_table = Table(

--- a/src/exosphere/commands/utils.py
+++ b/src/exosphere/commands/utils.py
@@ -316,7 +316,6 @@ def run_task_with_progress(
     immediate_error_display: bool = False,
     transient: bool = True,
     progress_args: tuple = (),
-    skipped: list[Host] | None = None,
 ) -> list[tuple[str, Exception]]:
     """
     Run a task on selected hosts with progress display.
@@ -347,12 +346,17 @@ def run_task_with_progress(
     :param transient: Whether progress bar disappears after completion
     :param progress_args: List of renderables to compose the Progress
         layout
-    :param skipped: Hosts that were skipped, to display with the
-        skipped status, when display_host is True. Purely for display.
     :return: List of (hostname, exception objects) tuples for any failed
         hosts
     """
     errors: list[tuple[str, Exception]] = []
+
+    # Pre-filter hosts based on whether or not they can run the operation
+    if operation.requires_supported:
+        skipped = [host for host in hosts if not host.supported]
+        hosts = [host for host in hosts if host.supported]
+    else:
+        skipped = []
 
     with Progress(transient=transient, *progress_args) as progress:
         task = progress.add_task(task_description, total=len(hosts))

--- a/src/exosphere/objects.py
+++ b/src/exosphere/objects.py
@@ -43,23 +43,38 @@ class HostOperation(Enum):
     If the operation does not (for instance, syncing repositories),
     this should be set to False, which allows operations to skip the
     cache writeout steps after completion.
+
+    The requires_supported boolean indicates whether the operation can
+    only run against a host on a supported platform. Host object level
+    implementations check this and return before dispatching, but
+    also documenting this here allows callers to pre-filter based on the
+    operation type, instead of just going for it, which saves threads
+    and potential false success/failure reports.
     """
 
-    # Tuple is (Host method name, display label, modifies local state)
-    PING = ("ping", "Ping", True)
-    DISCOVER = ("discover", "Discover", True)
-    REFRESH = ("refresh_updates", "Refresh Updates", True)
-    SYNC = ("sync_repos", "Sync Repositories", False)
+    # Tuple is (Host method, display label, modifies local state, needs support)
+    PING = ("ping", "Ping", True, False)
+    DISCOVER = ("discover", "Discover", True, False)
+    REFRESH = ("refresh_updates", "Refresh Updates", True, True)
+    SYNC = ("sync_repos", "Sync Repositories", False, True)
 
     # Annotations, not members
     label: str
     modifies_state: bool
+    requires_supported: bool
 
-    def __new__(cls, method: str, label: str, modifies_state: bool) -> "HostOperation":
+    def __new__(
+        cls,
+        method: str,
+        label: str,
+        modifies_state: bool,
+        requires_supported: bool,
+    ) -> "HostOperation":
         member = object.__new__(cls)
         member._value_ = method
         member.label = label
         member.modifies_state = modifies_state
+        member.requires_supported = requires_supported
         return member
 
 

--- a/src/exosphere/ui/app.py
+++ b/src/exosphere/ui/app.py
@@ -71,7 +71,6 @@ class ExosphereUi(App):
         hosts: list[Host] | None = None,
         *,
         message: str,
-        no_hosts_message: str,
         callback: Callable | None = None,
         report_result: bool = True,
     ) -> None:
@@ -94,7 +93,6 @@ class ExosphereUi(App):
         :param operation: The :class:`HostOperation` to run.
         :param hosts: Hosts to target, defaults to all hosts.
         :param message: Message to display in the progress screen.
-        :param no_hosts_message: Message shown if no hosts are available.
         :param callback: Optional callback to run after the task instead of
                          the default refresh bookkeeping.
         :param report_result: Whether a single-host task should report
@@ -112,8 +110,39 @@ class ExosphereUi(App):
         target_hosts = hosts if hosts is not None else inventory.hosts
         if not target_hosts:
             logging.warning("No hosts available to run task '%s'.", operation.value)
-            self.push_screen(ErrorScreen(no_hosts_message))
+            self.push_screen(ErrorScreen("No hosts available."))
             return
+
+        # Pre-filter unsupported hosts out of the target list if the
+        # requested operation requires it.
+        if operation.requires_supported:
+            skipped = [host for host in target_hosts if not host.supported]
+            if skipped:
+                logging.debug(
+                    "Skipping %d unsupported host(s) for task '%s': %s",
+                    len(skipped),
+                    operation.value,
+                    ", ".join(host.name for host in skipped),
+                )
+            supported_hosts = [host for host in target_hosts if host.supported]
+
+            # If nothing supported remains, the hosts exist but can't run
+            # this operation. Use a dedicated message to explain why.
+            if not supported_hosts:
+                logging.warning(
+                    "No supported hosts available to run task '%s'.", operation.value
+                )
+                if len(target_hosts) == 1:
+                    reason = (
+                        f"Host '{target_hosts[0].name}' is not running a "
+                        f"supported OS, cannot {operation.label.lower()}."
+                    )
+                else:
+                    reason = f"No supported hosts available for {operation.label}."
+                self.push_screen(ErrorScreen(reason))
+                return
+
+            target_hosts = supported_hosts
 
         # Generate default callback
         bookkeeping = self._after_task(operation)
@@ -141,7 +170,7 @@ class ExosphereUi(App):
         """
         Helper function that generates the default callback for the
         task runner in the TUI, which handles the bookkeeping
-        described above in :meth:`run_host_task`.
+        described above in run_host_task.
         """
 
         def callback(_) -> None:
@@ -234,7 +263,6 @@ class ExosphereUi(App):
             operation=operation,
             hosts=[host],
             message=f"Running {operation.label} on {host.name}...",
-            no_hosts_message=f"Host '{host.name}' is not available.",
         )
 
     def run_host_sync_refresh(self, host: Host) -> None:
@@ -258,7 +286,6 @@ class ExosphereUi(App):
             operation=HostOperation.SYNC,
             hosts=[host],
             message=f"Syncing repositories on {host.name}...",
-            no_hosts_message=f"Host '{host.name}' is not available.",
             callback=after_sync,
             report_result=False,
         )
@@ -268,7 +295,6 @@ class ExosphereUi(App):
         self.run_host_task(
             operation=operation,
             message=f"Running {operation.label} on all hosts...",
-            no_hosts_message="No hosts available.",
         )
 
     def run_sync_refresh_all(self) -> None:
@@ -289,7 +315,6 @@ class ExosphereUi(App):
         self.run_host_task(
             operation=HostOperation.SYNC,
             message="Syncing repositories on all hosts.\nThis may take a long time!",
-            no_hosts_message="No hosts available.",
             callback=after_sync,
             report_result=False,
         )

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -984,30 +984,7 @@ class TestRefreshCommand:
             display_hosts=False,
             collect_errors=True,
             immediate_error_display=False,
-            skipped=[],
         )
-
-    def test_refresh_skips_unsupported_hosts(self, mocker, mock_inventory, create_host):
-        """Refresh command skips unsupported hosts and informs"""
-        supported = create_host("supportedguy", supported=True)
-        unsupported = create_host("irixguy", supported=False)
-        mock_inventory.hosts = [supported, unsupported]
-
-        mock_run = mocker.patch.object(inventory_module, "run_task_with_progress")
-        mock_run.return_value = []
-
-        test_config = Configuration()
-        test_config.update_from_mapping({"options": {"cache_autosave": False}})
-        mocker.patch.object(inventory_module, "app_config", test_config)
-
-        code = inventory_module.app(["refresh", "--sync"], result_action="return_value")
-        assert code == 0
-
-        # Unsupported hosts should be sent to runner as skipped
-        assert mock_run.call_count == 2
-        for call in mock_run.call_args_list:
-            assert call.kwargs["hosts"] == [supported]
-            assert call.kwargs["skipped"] == [unsupported]
 
     def test_refresh_with_discover(self, mocker, mock_inventory, create_host):
         """Test refresh command with --discover option."""

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -366,14 +366,15 @@ class TestRunTaskWithProgress:
         mock_progress_instance.add_task.assert_called_once_with("Testing task", total=2)
         assert mock_progress_instance.update.call_count == 2
 
-    def test_run_task_displays_skipped_hosts(
-        self, mock_inventory, mock_console, mocker
+    @pytest.mark.parametrize("operation", [HostOperation.REFRESH, HostOperation.SYNC])
+    def test_run_task_skips_unsupported_hosts(
+        self, mock_inventory, mock_console, mocker, operation
     ):
-        """Skipped hosts are displayed separately from total progress"""
-        host1 = mocker.Mock()
+        """Operations requiring supported hosts should skip unsupported ones."""
+        host1 = mocker.Mock(supported=True)
         host1.name = "host1"
-        skipped_host = mocker.Mock()
-        skipped_host.name = "irixbox"
+        unsupported = mocker.Mock(supported=False)
+        unsupported.name = "irixbox"
 
         mock_inventory.run_task.return_value = [(host1, None, None)]
 
@@ -383,19 +384,18 @@ class TestRunTaskWithProgress:
 
         result = utils_module.run_task_with_progress(
             inventory=mock_inventory,
-            hosts=[host1],
-            operation=HostOperation.REFRESH,
-            task_description="Refreshing",
+            hosts=[host1, unsupported],
+            operation=operation,
+            task_description=f"Running {operation.label}",
             display_hosts=True,
-            skipped=[skipped_host],
         )
 
         assert result == []
-        # Only the runnable host is dispatched; total excludes the skipped one.
-        mock_inventory.run_task.assert_called_once_with(
-            HostOperation.REFRESH, hosts=[host1]
+        # Only the supported host is dispatched; total excludes the skipped one.
+        mock_inventory.run_task.assert_called_once_with(operation, hosts=[host1])
+        mock_progress_instance.add_task.assert_called_once_with(
+            f"Running {operation.label}", total=1
         )
-        mock_progress_instance.add_task.assert_called_once_with("Refreshing", total=1)
 
         # The skipped host is rendered with a SKIPPED status.
         rendered = [
@@ -405,6 +405,47 @@ class TestRunTaskWithProgress:
         ]
         assert any("SKIPPED" in chunk for chunk in rendered)
         assert any("irixbox" in chunk for chunk in rendered)
+
+    @pytest.mark.parametrize("operation", [HostOperation.DISCOVER, HostOperation.PING])
+    def test_run_task_does_not_skip_unsupported_hosts(
+        self, mock_inventory, mock_console, mocker, operation
+    ):
+        """Operations that don't require supported hosts should not skip any."""
+        host1 = mocker.Mock(supported=True)
+        host1.name = "host1"
+        unsupported = mocker.Mock(supported=False)
+        unsupported.name = "irixbox"
+
+        mock_inventory.run_task.return_value = [
+            (host1, None, None),
+            (unsupported, None, None),
+        ]
+
+        mock_progress = mocker.patch("exosphere.commands.utils.Progress")
+        mock_progress_instance = mock_progress.return_value.__enter__.return_value
+        mock_progress_instance.add_task.return_value = "task_id"
+
+        utils_module.run_task_with_progress(
+            inventory=mock_inventory,
+            hosts=[host1, unsupported],
+            operation=operation,
+            task_description="Working",
+            display_hosts=True,
+        )
+
+        # Both hosts are dispatched to and nothing is filtered out.
+        mock_inventory.run_task.assert_called_once_with(
+            operation, hosts=[host1, unsupported]
+        )
+        mock_progress_instance.add_task.assert_called_once_with("Working", total=2)
+
+        # Nothing should be rendered with a SKIPPED status.
+        rendered = [
+            str(renderable)
+            for call in mock_progress_instance.console.print.call_args_list
+            for renderable in getattr(call.args[0], "renderables", [])
+        ]
+        assert not any("SKIPPED" in chunk for chunk in rendered)
 
     def test_run_task_with_errors(self, mock_inventory, mock_console, mocker):
         """Test task execution with some errors."""

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -86,6 +86,21 @@ class TestHostOperation:
         """Sync should be stateless always"""
         assert HostOperation.SYNC.modifies_state is False
 
+    @pytest.mark.parametrize("op", list(HostOperation))
+    def test_requires_supported_is_bool(self, op):
+        """Each member exposes a boolean requires_supported flag."""
+        assert isinstance(op.requires_supported, bool)
+
+    def test_discover_and_ping_run_on_unsupported(self):
+        """Discovery and ping must reach hosts regardless of support."""
+        assert HostOperation.DISCOVER.requires_supported is False
+        assert HostOperation.PING.requires_supported is False
+
+    def test_sync_and_refresh_require_supported(self):
+        """Sync and refresh only make sense on supported hosts."""
+        assert HostOperation.SYNC.requires_supported is True
+        assert HostOperation.REFRESH.requires_supported is True
+
 
 class TestHostObject:
     @pytest.fixture(autouse=True)

--- a/tests/ui/test_app.py
+++ b/tests/ui/test_app.py
@@ -258,7 +258,7 @@ class TestExosphereUi:
         mock_context.inventory = None
         push = mocker.patch.object(app, "push_screen")
 
-        app.run_host_task(HostOperation.PING, message="m", no_hosts_message="nh")
+        app.run_host_task(HostOperation.PING, message="m")
 
         push.assert_called_once()
         pushed = push.call_args[0][0]
@@ -266,18 +266,16 @@ class TestExosphereUi:
         assert "not initialized" in pushed.message.lower()
 
     def test_run_host_task_no_hosts_pushes_error(self, app, mocker, mock_context):
-        """run_host_task pushes an ErrorScreen with the no_hosts message."""
+        """run_host_task pushes an ErrorScreen when no hosts are available."""
         mock_context.inventory = mocker.Mock(hosts=[])
         push = mocker.patch.object(app, "push_screen")
 
-        app.run_host_task(
-            HostOperation.PING, message="m", no_hosts_message="No hosts here!"
-        )
+        app.run_host_task(HostOperation.PING, message="m")
 
         push.assert_called_once()
         pushed = push.call_args[0][0]
         assert isinstance(pushed, ErrorScreen)
-        assert pushed.message == "No hosts here!"
+        assert pushed.message == "No hosts available."
 
     def test_run_host_task_pushes_progress_screen(self, app, mocker, mock_context):
         """run_host_task pushes a ProgressScreen carrying the operation."""
@@ -285,9 +283,7 @@ class TestExosphereUi:
         mock_context.inventory = mocker.Mock(hosts=[host])
         push = mocker.patch.object(app, "push_screen")
 
-        app.run_host_task(
-            HostOperation.REFRESH, message="Refreshing", no_hosts_message="nh"
-        )
+        app.run_host_task(HostOperation.REFRESH, message="Refreshing")
 
         push.assert_called_once()
         pushed = push.call_args[0][0]
@@ -302,12 +298,81 @@ class TestExosphereUi:
         mock_context.inventory = mocker.Mock(hosts=[h1, h2, h3])
         push = mocker.patch.object(app, "push_screen")
 
-        app.run_host_task(
-            HostOperation.PING, hosts=[h2], message="m", no_hosts_message="nh"
-        )
+        app.run_host_task(HostOperation.PING, hosts=[h2], message="m")
 
         pushed = push.call_args[0][0]
         assert pushed.hosts == [h2]
+
+    @pytest.mark.parametrize(
+        "operation, keeps_unsupported",
+        [
+            (HostOperation.REFRESH, False),
+            (HostOperation.SYNC, False),
+            (HostOperation.DISCOVER, True),
+            (HostOperation.PING, True),
+        ],
+        ids=[
+            "refresh_drops_unsupported",
+            "sync_drops_unsupported",
+            "discover_keeps_unsupported",
+            "ping_keeps_unsupported",
+        ],
+    )
+    def test_run_host_task_filters_unsupported(
+        self, app, mocker, mock_context, operation, keeps_unsupported
+    ):
+        """Unsupported hosts are dropped only for support-requiring ops."""
+        supported = mocker.Mock(supported=True)
+
+        unsupported = mocker.Mock(supported=False)
+        unsupported.name = "unsupported"
+
+        mock_context.inventory = mocker.Mock(hosts=[supported, unsupported])
+        push = mocker.patch.object(app, "push_screen")
+
+        app.run_host_task(operation, message="m")
+
+        pushed = push.call_args[0][0]
+        assert isinstance(pushed, ProgressScreen)
+        expected = [supported, unsupported] if keeps_unsupported else [supported]
+        assert pushed.hosts == expected
+
+    def test_run_host_task_all_unsupported_single_host_names_reason(
+        self, app, mocker, mock_context
+    ):
+        """A single unsupported host errors with a message naming the host."""
+        unsupported = mocker.Mock(supported=False)
+        unsupported.name = "irixbox"
+        mock_context.inventory = mocker.Mock(hosts=[unsupported])
+        push = mocker.patch.object(app, "push_screen")
+
+        # The host exists, it's just unsupported: the dedicated message
+        # names the real reason rather than a generic "no hosts" one.
+        app.run_host_task(HostOperation.SYNC, message="m")
+
+        push.assert_called_once()
+        pushed = push.call_args[0][0]
+        assert isinstance(pushed, ErrorScreen)
+        assert "irixbox" in pushed.message
+        assert "supported" in pushed.message.lower()
+
+    def test_run_host_task_all_unsupported_many_hosts_generic_reason(
+        self, app, mocker, mock_context
+    ):
+        """Multiple unsupported hosts get a generic supported-hosts message."""
+        h1 = mocker.Mock(supported=False)
+        h1.name = "irixbox"
+        h2 = mocker.Mock(supported=False)
+        h2.name = "vaxen"
+        mock_context.inventory = mocker.Mock(hosts=[h1, h2])
+        push = mocker.patch.object(app, "push_screen")
+
+        app.run_host_task(HostOperation.SYNC, message="m")
+
+        push.assert_called_once()
+        pushed = push.call_args[0][0]
+        assert isinstance(pushed, ErrorScreen)
+        assert "No supported hosts" in pushed.message
 
     def test_run_host_task_invokes_custom_callback_on_complete(
         self, app, mocker, mock_context
@@ -317,9 +382,7 @@ class TestExosphereUi:
         push = mocker.patch.object(app, "push_screen")
         custom = mocker.Mock()
 
-        app.run_host_task(
-            HostOperation.PING, message="m", no_hosts_message="nh", callback=custom
-        )
+        app.run_host_task(HostOperation.PING, message="m", callback=custom)
 
         # push_screen gets a wrapper; invoking it with an outcome runs the
         # custom callback (after rendering feedback).
@@ -337,7 +400,6 @@ class TestExosphereUi:
         app.run_host_task(
             HostOperation.REFRESH,
             message="a message",
-            no_hosts_message="no boys here",
             report_result=False,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0.dev20"
+version = "3.0.0.dev21"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Lightly rework the task dispatch logic across CLI and TUI thread pool controllers.

Earlier changes previously added pre-filtering to the CLI so it would skip unsupported hosts, removing them from the target list, before sending it to the thread pool dispatcher. This also allowed the CLI to report on skipped hosts in verbose mode.

The TUI, however, was still just sending everything and letting the early exit in the Host method handle it.

This was inconsistent, and bugged me, and also meant that we consumed a thread in the pool (not really meaningful, since it returned immediately, but still) for each unsupported host, and also ran the risk of tripping on false positives and false negative status messages in some edge cases.

The "requires a supported host" criteria has been made part of the HostOperation enum, and the dispatch logic now pre-filters on its own in BOTH cases (CLI and TUI) instead of delegating this to the callers.

In the same vein, the TUI no longer requires a message to display when no hosts are available, since the dispatcher logic now has all the information it needs to determine the proper error message on its own.

It's a small thing, but it makes things much more consistent.