### PR TITLE
Docs: Fix minor grammar and render nits

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -37,7 +37,7 @@ Three concepts carry most of the weight:
     One remote system Exosphere connects to.
 
 **Inventory**
-    The full collection of hosts, defined in your :doc:`configuration`.
+    The full collection of hosts, which are defined in your :doc:`configuration <configuration>`.
     Most commands operate on the whole inventory unless you name specific hosts.
 
 **Provider**

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -15,7 +15,7 @@ Create ``config.yaml`` in the `Config` directory shown here.
 .. tip::
 
     You can also use `config.toml` or `config.json` if you prefer those formats.
-    See the :doc:`configuration` page for more details.
+    See the :doc:`configuration <configuration>` page for more details.
 
 
 **Basic configuration**
@@ -114,7 +114,7 @@ Or start the full :doc:`ui` for a more interactive experience:
 .. tip::
 
    For more advanced configuration options, authentication details, and troubleshooting,
-   see the full :doc:`configuration` and :doc:`connections` documentation.
+   see the full :doc:`configuration <configuration>` and :doc:`connections <connections>` documentation.
 
    The :doc:`faq` section may also be helpful for common questions and issues.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exosphere-cli"
-version = "3.0.0"
+version = "3.0.1.dev0"
 description = "CLI/TUI driven patch reporting for remote Unix-like systems."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ wheels = [
 
 [[package]]
 name = "exosphere-cli"
-version = "3.0.0"
+version = "3.0.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Ensure :doc: links read well when the full title is rendered out. Fix dubious use of comma in concepts.rst.