### PR TITLE
Docs: Refresh documentation post 3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ uv run textual run --dev -c exosphere ui
 Congratulations! Editing any of the `.tcss` files in the `ui/` directory will
 reflect changes immediately.
 
-
 ### Documentation Editing Quick Start
 
 To edit the documentation, you can use the following commands:
@@ -147,8 +146,10 @@ tasks are defined in the `pyproject.toml` file under the `[tool.poe.tasks]` tabl
 
 | path | description |
 | ---- | ----------- |
+| `LICENSES/` | Full text of every license used by the project and its assets |
 | `docs/` | Sphinx documentation source tree |
 | `docs/source/_ext/` | Custom Sphinx extensions for the project |
+| `docs/source/changelog/` | Per-release changelog entries (markdown) and their assets |
 | `examples/` | Example configuration files and reports |
 | `scripts/` | Utilitarian scripts for dev and maintenance |
 | `src/` | Main source code for the application |
@@ -183,13 +184,16 @@ Paths below are relative to `src/exosphere/` unless otherwise noted.
 | `context.py` | Context management for shared state across commands and UI |
 | `data.py` | Data models and structures for serialization and exchange |
 | `database.py` | Cache system for serialization |
+| `editing.py` | External editor helper module, shared between CLI and UI |
 | `errors.py` | Exception classes and general error messages |
+| `fspaths.py` | Platform-appropriate filesystem paths module, for state |
 | `inventory.py` | Inventory management subsystem |
 | `migrations.py` | Cache format migration processes |
 | `objects.py` | Main objects for representing Hosts, and most of the relevant logic |
 | `pipelining.py` | SSH pipelining implementation, including reaper thread |
 | `repl.py` | REPL module for interactive CLI usage |
 | `reporting.py` | Reporting subsystem, including templates and formatters |
+| `runners.py` | SSH runners module, handles setting up remote POSIX environment |
 | `security.py` | Sudo management subsystem, including policy and utilities |
 
 Generally, most of the things Exosphere does to hosts (including connection management
@@ -204,9 +208,9 @@ Paths below are relative to `src/exosphere/` unless otherwise noted.
 | `ui/app.py` | Main Textual application class and entry point for the UI |
 | `ui/context.py` | UI Context management for shared state across UI components |
 | `ui/elements.py` | Shared UI elements, including task runners |
-| `ui/dashboard.py` | Dashboard view implementation |
-| `ui/inventory.py` | Inventory view implementation |
-| `ui/logs.py` | Logs view implementation |
+| `ui/dashboard.py` | Dashboard screen implementation |
+| `ui/inventory.py` | Inventory screen implementation |
+| `ui/logs.py` | Logs screen implementation |
 | `ui/messages.py` | Screen refresh and message passing system |
 | `ui/palette.py` | Command palette providers and implementations |
 

--- a/docs/source/_ext/exosphere_cli_format.py
+++ b/docs/source/_ext/exosphere_cli_format.py
@@ -16,19 +16,18 @@ exclusively to the "command reference" section.
 """
 
 from docutils import nodes
-from sphinx.util import logging
-
-logger = logging.getLogger(__name__)
 
 # We only apply this dirty hack to the command reference section
 TARGET_DOCNAME = "command_reference"
 
+# Prefixes for anchors, internal and external
+CYCLOPTS_ANCHOR_PREFIX = "cyclopts-"
+PUBLIC_ANCHOR_PREFIX = "exosphere-"
+
 
 def _first_paragraph(section):
     """Return the first direct-child paragraph of a section, or None."""
-    return next(
-        (c for c in section.children if isinstance(c, nodes.paragraph)), None
-    )
+    return next((c for c in section.children if isinstance(c, nodes.paragraph)), None)
 
 
 def promote_command_summaries(app, doctree):
@@ -86,9 +85,68 @@ def promote_command_summaries(app, doctree):
         summary.children = [nodes.strong("", "", *summary.children)]
 
 
+def namespace_command_anchors(app, doctree):
+    """
+    Make the namespaced anchor the primary id of each command section.
+
+    Sucommand names can clash across commands (i.e. inventory discover
+    vs host discover, anything with 'show' etc). As a result the
+    stupid toctree will contain a bunch of anchor links within sections
+    all claiming '#discover' or '#show' for themselves and every link
+    will land on whichever sorted first in the document, which is not
+    desirable in any way shape or form.
+
+    Cyclopts already has a unique ``.. _cyclopts-<group>-<command>:``
+    label for each command, so the section carries a perfectly good
+    namespaced id as well, it's just, infuriatingly, not the one
+    being used:
+
+        ids = ["discover", "cyclopts-inventory-discover"]
+
+    So this function just promotes the namespaced id to the top while
+    renaming the prefix so it doesn't look ass in user facing links, and
+    drops the bare one, which fixes the navigation, gets rid of
+    duplicate id attributes in the output, solves world hunger and
+    waters my plants.
+
+    We also keep the original id as a secondary anchor on purpose to
+    name the sections and honor ``:ref:`` links, if any.
+
+    This should run *before* the toctree collector, to ensure it
+    happens before the ids are picked up, and should be connected in
+    setup() with a priority of 400, otherwise it won't be effective.
+    """
+    if app.env.docname != TARGET_DOCNAME:
+        return
+
+    for section in doctree.findall(nodes.section):
+        ids = section["ids"]
+
+        qualified = next((i for i in ids if i.startswith(CYCLOPTS_ANCHOR_PREFIX)), None)
+
+        if qualified is None:
+            continue
+
+        public = PUBLIC_ANCHOR_PREFIX + qualified.removeprefix(CYCLOPTS_ANCHOR_PREFIX)
+
+        if ids[0] == public:
+            continue
+
+        # A good traditional dirty print for useful output during build
+        print(f"Renaming command anchor {ids[0]} -> {public} in {TARGET_DOCNAME}")
+
+        section["ids"] = [public, qualified]
+
+        # Keep docutils' id bookkeeping aware of the anchor we just
+        # invented, so nothing else can lay claim to it later on.
+        # It's also good form, and polite. Probably.
+        doctree.ids.setdefault(public, section)
+
+
 def setup(app):
     print("[INFO] Exosphere CLI Help Hack extension loaded")
 
+    app.connect("doctree-read", namespace_command_anchors, priority=400)
     app.connect("doctree-read", promote_command_summaries)
 
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/_ext/exosphere_cli_format.py
+++ b/docs/source/_ext/exosphere_cli_format.py
@@ -24,10 +24,31 @@ TARGET_DOCNAME = "command_reference"
 CYCLOPTS_ANCHOR_PREFIX = "cyclopts-"
 PUBLIC_ANCHOR_PREFIX = "exosphere-"
 
+# Class tagged on subcommand sections
+# Helper intended purely to lubricatre CSS styling
+SUBCOMMAND_SECTION_CLASS = "exosphere-subcommand"
+
 
 def _first_paragraph(section):
     """Return the first direct-child paragraph of a section, or None."""
     return next((c for c in section.children if isinstance(c, nodes.paragraph)), None)
+
+
+def tag_subcommand_sections(app, doctree):
+    """
+    Tag a class on every subcommand section, purely as a CSS hook.
+
+    See exosphere-overrides.css for details, but the gist of it is
+    that we want to format the subcommands slightly differently, and
+    this is the path of least resistance to being able to distinguish
+    them.
+    """
+    if app.env.docname != TARGET_DOCNAME:
+        return
+
+    for section in doctree.findall(nodes.section):
+        if any(isinstance(child, nodes.literal_block) for child in section.children):
+            section["classes"].append(SUBCOMMAND_SECTION_CLASS)
 
 
 def promote_command_summaries(app, doctree):
@@ -148,5 +169,6 @@ def setup(app):
 
     app.connect("doctree-read", namespace_command_anchors, priority=400)
     app.connect("doctree-read", promote_command_summaries)
+    app.connect("doctree-read", tag_subcommand_sections)
 
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/source/_static/css/exosphere-overrides.css
+++ b/docs/source/_static/css/exosphere-overrides.css
@@ -161,15 +161,28 @@ a:focus {
     margin-left: 0.3em;
 }
 
-/* String Literals */
+/* String Literals
+ *
+ * We use a lot of them and I like boxes, and since they're
+ * visually busy, we make them borderless.
+ *
+ * Intended to be translucent-like, with a tint, so it looks good
+ * in most contexts, and inherits the color which immediately takes
+ * the look from sysadmin docs to wow super pro.
+ *
+ * font-size is 0.86em en purpose to accomodate Source Code Pro
+ * as a font, which has a different x-height and I have been
+ * fighting this forever, and this magical value makes it look
+ * cohesive.
+ */
 .rst-content code.literal,
 .rst-content tt.literal {
-    background: #ebebeb;
-    color: #3d3d3d;
-    border: 1px solid #d4d4d4;
+    background: rgba(13, 59, 89, 0.08);
+    color: inherit;
+    border: 0;
     border-radius: 3px;
-    padding: 0.1em 0.35em;
-    font-size: 0.8em;
+    padding: 0.12em 0.34em;
+    font-size: 0.86em;
 }
 
 .rst-content .note {

--- a/docs/source/_static/css/exosphere-overrides.css
+++ b/docs/source/_static/css/exosphere-overrides.css
@@ -185,6 +185,27 @@ a:focus {
     font-size: 0.86em;
 }
 
+/* CLI Command Reference subcommands
+ *
+ * The section class is tacked on by a custom sphinx extension, and allows
+ * us to generally distinguish subcommand sections from command ones.
+ *
+ * Subcommand sections are indently slightly under the parent command with
+ * a hairline rule on the lefthand side. Hairline follows the same translucent
+ * tint rules as the string literals.
+ */
+.rst-content section.exosphere-subcommand {
+    padding-left: 1.25rem;
+    border-left: 2px solid rgba(13, 59, 89, 0.1);
+}
+
+/* Make that much less pronounced on small screens where every pixel counts */
+@media screen and (max-width: 768px) {
+    .rst-content section.exosphere-subcommand {
+        padding-left: 0.5rem;
+    }
+}
+
 .rst-content .note {
     color: #003274;
     background: #ccddf3;

--- a/docs/source/cachefile.rst
+++ b/docs/source/cachefile.rst
@@ -25,6 +25,39 @@ If it does not, this is a bug and should be reported.
     upgrade on load. However, if you encounter issues, consider clearing
     the cache as described below.
 
+.. _cache_locking:
+
+Cache Locking & Concurrent Instances
+------------------------------------
+
+Since **3.0** Exosphere actively guards against multiple instances trying to
+interact with the same cache file, and uses locks to achieve this.
+
+The lock file is placed next to the cache file itself (with the ``.lock``
+extension appended), so that the cache file itself is never held open.
+
+The lock is released when the process exits.
+
+If a second instance is started against the same cache, it will refuse to start
+with a message along these lines:
+
+.. code-block:: text
+
+    FATAL: Another Exosphere instance is using this cache:
+      /home/alice/.local/state/exosphere/exosphere.db
+    Ensure no other instances with this configuration are running.
+
+This worked in previous versions, but was never a supported configuration.
+Two instances sharing a cache would inevitably overwrite each other, and the
+cache is never reloaded at runtime, leading to sub-optimal outcomes.
+
+.. tip::
+
+    If you genuinely need to run two instances side by side (for example, against
+    two separate inventories), give each one its own configuration with a distinct
+    :option:`cache_file`. They will then take separate locks and each will be
+    able to coexist peacefully.
+
 Clearing the Cache
 ------------------
 If you encounter issues or inconsistencies with the cache, you can clear it.

--- a/docs/source/changelog/3.0.0.md
+++ b/docs/source/changelog/3.0.0.md
@@ -115,8 +115,8 @@ A few small but helpful new commands have been added:
 * `report status` -- a very short, two or three lines summary of the current state
   of the inventory. Suitable for inclusion in scripts or system MOTD.
 
-All of these are documented more extensively in the {doc}`../cli` docs as well
-as the {doc}`../reporting` docs.
+All of these are documented more extensively in the {doc}`CLI <../cli>` docs as
+well as the {doc}`reporting <../reporting>` docs.
 
 ### The Web UI has been removed
 

--- a/docs/source/changelog/3.0.1.md
+++ b/docs/source/changelog/3.0.1.md
@@ -4,7 +4,8 @@
 
 ## What's New?
 
-Minor cleanups and documentation fixes.
+A few minor edge case bugfixes, and documentation improvements that were long
+overdue and missed the window for 3.0.
 
 ## Bug Fixes
 
@@ -15,4 +16,9 @@ Minor cleanups and documentation fixes.
 
 ## Documentation
 
-- Docs: Fix minor grammar and render nits
+- Fix multiple grammar, structure and rendering issues
+- Update the Documentation index to be in sync with the README
+- Document cache file locking mechanics in the appropriate section
+- Fix issue with CLI Command Reference linking to wrong section anchors for
+  subcommands sharing a name
+- Improve presentation of string literal boxes throughout the documentation

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -12,7 +12,7 @@ The CLI itself has two main modes of operation:
 
 Normal Mode
    This is the default mode where you can run exosphere commands directly as
-   arguments to the `exosphere` command.
+   arguments to the ``exosphere`` command.
 
 Interactive Mode
    You can enter an interactive shell by running ``exosphere`` without any arguments.
@@ -180,7 +180,7 @@ The available sort columns are ``host``, ``os``, ``flavor``, ``version``,
 
 Sorting and filtering **can be combined freely**.
 
-A useful filter and sort combo you might find useful out of the box would be:
+A filter and sort combination you might find useful out of the box would be:
 
 .. code-block:: exosphere
 
@@ -322,7 +322,7 @@ configuration file exists yet, the default platform path is opened instead, so
 you can create one from scratch.
 
 The editor used is determined from the :option:`editor` configuration option.
-In its absence, it will fallback to the ``VISUAL`` and ``EDITOR`` environment
+In its absence, it will fall back to the ``VISUAL`` and ``EDITOR`` environment
 variables, and finally a platform default (``notepad`` on Windows, ``vi``
 elsewhere).
 

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -71,7 +71,7 @@ Working with your hosts follows a simple loop:
    entirely read-only.
 3. **Repository Sync** *(optional)*: refresh the host's own package metadata
    first, so the next Refresh sees the very latest. This is the one step that
-   may require :doc:`sudo` on some platforms.
+   may require :doc:`sudo privileges <sudo>` on some platforms.
 4. **View / Report**: look at the results, via the :doc:`cli` status tables,
    the interactive :doc:`ui`, or generated :doc:`reports <reporting>`.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_tabs.tabs',
     'sphinxcontrib.spelling',
-    'cyclopts.sphinx_ext',
+    'cyclopts.ext.sphinx',
     'exosphere_lexer',  # Custom Exosphere CLI lexer
     'exosphere_help',  # Custom Exosphere CLI help SVG renderer
     'exosphere_artifacts',  # Custom extension to copy artifacts to _static

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -25,7 +25,7 @@ For instance, for a **YAML** configuration file, the default locations are:
 
         ``%LOCALAPPDATA%\exosphere\config.yaml``
 
-You can of course substitute the file extension with `.toml` or `.json` if you wish
+You can of course substitute the file extension with ``.toml`` or ``.json`` if you wish
 to use those formats instead.
 
 You can also ask Exosphere where it expects the configuration file to be on your
@@ -99,8 +99,8 @@ file you wish to use.
     will be searched for. This can be useful in certain deployments.
 
 Exosphere also supports loading configuration options from environment variables.
-You can use this to override any specific `Option` from the configuration file.
-You cannot use environment variables to override the `Hosts` section.
+You can use this to override any specific ``options`` from the configuration file.
+You cannot use environment variables to override the ``hosts`` section.
 
 The environment variable names are prefixed with ``EXOSPHERE_OPTIONS_`` and
 the option name in uppercase.
@@ -236,7 +236,7 @@ and examples of how to set them in the configuration file.
       commands without a password
 
     This controls how Exosphere will handle sudo permissions when running commands
-    on hosts. The default is `skip`, which means Exosphere will not attempt to use
+    on hosts. The default is ``skip``, which means Exosphere will not attempt to use
     sudo at all.
 
     If you want Exosphere to run commands that require elevated privileges at all,
@@ -253,7 +253,7 @@ and examples of how to set them in the configuration file.
 
         This is the global value that, by default, applies to all hosts.
         It can be overridden on a per-host basis in the inventory, inside
-        the `hosts` section, via :option:`sudo_policy`.
+        the ``hosts`` section, via :option:`sudo_policy`.
 
 
     **Default**: ``skip``
@@ -750,7 +750,7 @@ and examples of how to set them in the configuration file.
 
         This is the global value that, by default, applies to all hosts.
         It can be overridden on a per-host basis in the inventory, inside
-        the `hosts` section, via :option:`connect_timeout`.
+        the ``hosts`` section, via :option:`connect_timeout`.
 
 
     **Default**: ``10`` (seconds)
@@ -798,7 +798,7 @@ and examples of how to set them in the configuration file.
 
         This is the global value that, by default, applies to all hosts.
         It can be overridden on a per-host basis in the inventory, inside
-        the `hosts` section, via :option:`username`.
+        the ``hosts`` section, via :option:`username`.
 
     **Default**: ``None`` (Current user's username)
 
@@ -1282,10 +1282,10 @@ and examples of how to set them in the configuration file.
 Inventory
 ---------
 
-The second section of the configuration file is the `Hosts` section, which is
+The second section of the configuration file is the ``hosts`` section, which is
 referred to throughout the documentation as **The Inventory**.
 
-The `Hosts` section contains a list of hosts that Exosphere will connect to, as well
+The ``hosts`` section contains a list of hosts that Exosphere will connect to, as well
 as their connection parameters and any specific option for each host.
 
 Host entries are structured as follows. This example describes two hosts, one of which

--- a/docs/source/connections.rst
+++ b/docs/source/connections.rst
@@ -77,7 +77,7 @@ Authentication failures will display clearly in the output. The exact cause, how
 vary, but you should check the following:
 
 * Ensure your SSH agent is running and has the necessary keys loaded.
-* Ensure the username and port are correct in :doc:`configuration`
+* Ensure the username and port are correct in your :doc:`configuration file <configuration>`
 * Ensure the remote host is reachable over the network and that the SSH service is running.
 * Ensure the remote host's SSH configuration allows *Public Key Authentication*
 

--- a/docs/source/connections.rst
+++ b/docs/source/connections.rst
@@ -149,7 +149,7 @@ as well as:
 
     exosphere> connections close
 
-See the `connections` command help for more details.
+See the ``connections`` command help for more details.
 
 The configurable values for SSH Pipelining include the :ref:`maximum lifetime
 of idle connections <ssh_pipelining_lifetime_option>`, as well as the

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -124,7 +124,7 @@ Can I specify a custom path for the configuration file?
 Yes! You can specify a custom path for the configuration file by setting the
 ``EXOSPHERE_CONFIG_FILE`` environment variable to the full path of the file you wish to use.
 
-See :doc:`configuration` for more details on other environment variables
+See the :doc:`configuration <configuration>` page for more details on other environment variables
 you can define to influence or override the configuration.
 
 I don't like the ascii art banner in interactive mode

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -13,7 +13,7 @@ Unfortunately, no. Exosphere is not a configuration management or automation
 tool, simply a reporting and aggregation tool.
 
 The gap it exists to fill is providing you with a unified, centralized view
-of the `state` of updates and patches across your systems, so you can
+of the *state* of updates and patches across your systems, so you can
 make informed decisions about what needs patching, and when.
 
 This functionality is not planned, and left to frankly better tooling that
@@ -92,8 +92,8 @@ It only supports Binary Packages, for both FreeBSD and OpenBSD.
 There are plans to add support for system updates in the future, presenting
 them as a synthetic package in the updates view, but this needs more work.
 
-For the time being, cron reports and mailing lists for `syspatch` and
-`freebsd-update` are recommended to keep tabs on these.
+For the time being, cron reports and mailing lists for ``syspatch`` and
+``freebsd-update`` are recommended to keep tabs on these.
 
 Does FreeBSD support extend to things like OPNSense?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -156,7 +156,7 @@ Troubleshooting
 Why does ping report Offline when the system is reachable?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``ping`` checks in exosphere aren't ICMP ping, but SSH pings.
+The ``ping`` checks in Exosphere aren't ICMP pings, but SSH pings.
 They will only return an Online status if the remote system can be
 connected to successfully, over SSH, and a simple POSIX test command
 can be executed. (``/bin/true`` or shell built-in equivalent)
@@ -176,8 +176,8 @@ but is currently shutting down, or has not finished booting.
 Generally, if the host shows up as Offline, you would not be able to
 perform any of the other operations on it anyways.
 
-You can re-run the ``discovery`` command to find out what the issue is and
-correct it, if you are getting this during initial setup.
+You can re-run the ``inventory discover`` command to find out what the issue is
+and correct it, if you are getting this during initial setup.
 
 I get an error with "Private key file is encrypted", what does it mean?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -190,7 +190,7 @@ Verify that:
 - Your SSH agent is running and has the correct key loaded
 - The right user name is being used to connect
 
-The unhelpful error message is unfortunately a `Known Issue`_ in the `paramiko`
+The unhelpful error message is unfortunately a `Known Issue`_ in the ``paramiko``
 library, which is used internally to handle SSH connections. Whenever
 authentication fails when an SSH agent is used, this is the exception
 that will be raised, regardless of the actual issue.
@@ -198,10 +198,10 @@ that will be raised, regardless of the actual issue.
 Exosphere will generally catch this specific error and rewrite the error message
 to be more helpful, but there are a few edge cases where it may be displayed as-is.
 
-My system using `dnf` or `yum` hangs when refreshing
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+My system using ``dnf`` or ``yum`` hangs when refreshing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The `dnf` and `yum` providers do a best effort to prevent interactive
+The ``dnf`` and ``yum`` providers do a best effort to prevent interactive
 prompts when running the commands they need to synchronize repositories
 and cache, but sometimes, they will still prompt for user input, which
 Exosphere cannot handle.
@@ -227,18 +227,18 @@ user you use within Exosphere, and manually run the following commands:
 And answer all the prompts that may appear. The provider should no longer hang
 past this point.
 
-After an update, my system using `dnf` fails to refresh!
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+After an update, my system using ``dnf`` fails to refresh!
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After certain types of updates, you may get the following error message when
-trying to refresh a `dnf` based system:
+trying to refresh a ``dnf`` based system:
 
 .. code-block:: text
 
     Failed to get current versions: Error: SQLite error on "/var/lib/dnf/history.sqlite":
     Executing an SQL statement failed: attempt to write a readonly database
 
-This is a known issue where `dnf` apparently needs to perform some database
+This is a known issue where ``dnf`` apparently needs to perform some database
 updates before it can perform its queries. This requires root privileges, which
 Exosphere does not have access to during normal operations.
 
@@ -281,7 +281,7 @@ Updates refresh fails on my OpenBSD system with an exotic architecture!
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Exosphere relies on the availability of the ``syspatch`` command to determine
-if the system is tracking a stable release or `-current`.
+if the system is tracking a stable release or ``-current``.
 
 If you're running a more exotic, non-x86 architecture, Exosphere may not
 be able to handle the failure mode gracefully, and we'd deeply appreciate

--- a/docs/source/gettinghelp.rst
+++ b/docs/source/gettinghelp.rst
@@ -1,7 +1,7 @@
 Getting Help
 ============
 
-While exosphere is provided as-is, with no expectation of warranty or support,
+While Exosphere is provided as-is, with no expectation of warranty or support,
 there are a few resources available for help if you run into issues or have questions.
 
 Before reaching out

--- a/docs/source/gettinghelp.rst
+++ b/docs/source/gettinghelp.rst
@@ -55,7 +55,7 @@ Feature requests and ideas
 
 Suggestions are welcome. Open a discussion on `GitHub Discussions`_, or an issue
 via the `bug report form`_ --- whichever feels more appropriate. If you have
-built something neat on top of Exosphere's :doc:`reporting` (a dashboard, a bot,
+built something neat on top of Exosphere's :doc:`reporting output <reporting>` (a dashboard, a bot,
 a coffee-brewing cron job), we would love to hear about it.
 
 .. _GitHub Discussions: https://github.com/mrdaemon/exosphere/discussions

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -17,7 +17,7 @@ Inventory
 Provider
     A Provider is a platform-specific implementation of a package manager
     interface that Exosphere uses to gather information. For instance, on
-    Debian and Ubuntu systems, the `apt` provider is used.
+    Debian and Ubuntu systems, the ``apt`` provider is used.
 
     Providers are generally not exposed directly through configuration, just
     automatically detected based on the platform.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -32,6 +32,20 @@ Security
     in the software installed on the Host. Exosphere will generally report these
     with some form of emphasis, as they are more urgent than regular updates.
 
+Pending Reboot
+    A host is considered to have a Pending Reboot when updates have been applied
+    that will not take effect until the operating system is restarted, usually
+    pertaining to changes in shared, core libraries or a new kernel.
+
+    Exosphere attempts to determine this on a best-effort basis during a Refresh
+    operation, on supported platforms.
+
+Stale
+    Host data is considered stale when it has not been refreshed for a while.
+    How long is configurable with the :option:`stale_threshold` configuration
+    option, with a default of 24 hours. This indicates the host should be
+    refreshed, as the state possibly no longer reflects reality.
+
 Discovery
     Discovery is the initial process through which Exosphere connects to a host
     and tries to determine platform details. This usually consists of:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,8 +48,9 @@ on management of your systems.
 You can get started with :doc:`installation` and then follow up
 with the :doc:`quickstart` to get an overview of how to use Exosphere.
 
-:doc:`configuration` details are also available, alongside the
-:doc:`api/index` if you wish to implement your own providers.
+The :doc:`configuration <configuration>` reference is also available, alongside
+the :doc:`API documentation <api/index>` if you wish to implement your own
+providers.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ It is meant to be simple to deploy and use, requiring no central server,
 agents or complex dependencies on remote hosts.
 
 If you have SSH access to the hosts and your key pairs are loaded in an SSH
-`_agent`, you are good to go!
+`agent`_, you are good to go!
 
 **Key Features**
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,9 @@
 Welcome to Exosphere
 =====================
 
-Exosphere offers aggregated patch and security update reporting as
-well as basic system status across multiple Unix-like hosts via SSH.
+Exosphere is a CLI and Text UI driven application that offers aggregated patch
+and security update reporting as well as basic system status across multiple
+Unix-like hosts over SSH.
 
 .. figure:: _static/demo.gif
    :alt: Exosphere demo
@@ -15,7 +16,8 @@ It is targeted at small to medium sized networks.
 It is meant to be simple to deploy and use, requiring no central server,
 agents or complex dependencies on remote hosts.
 
-If you have SSH access to the hosts with an `agent`_, you are good to go!
+If you have SSH access to the hosts and your key pairs are loaded in an SSH
+`_agent`, you are good to go!
 
 **Key Features**
 
@@ -24,6 +26,8 @@ If you have SSH access to the hosts with an `agent`_, you are good to go!
 - Consistent view across different platforms and package managers
 - See everything in one spot, at a glance, without complex automation
   or enterprise solutions.
+- Does not require Python (or anything else) to be installed on remote systems
+- Parallel operations across hosts with optional SSH pipelining
 - Document-based reporting in HTML, text or markdown format
 - JSON output available for integration with other tools
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -78,9 +78,11 @@ having to contend with potential conflicts with other Python packages.
 The main difference is that ``uv tool`` will also download and manage the necessary
 Python runtime for you, if you do not have a suitable version available.
 
-``pip install`` is **not recommended** outside of a venv, as it *will* interfere
-with other Python packages and system versions of the libraries, and many
-distributions will in fact not allow you to install it that way.
+.. caution::
+
+    ``pip install`` is **not recommended** outside of a venv, as it *will* interfere
+    with other Python packages and system versions of the libraries, and many
+    distributions will in fact not allow you to install it that way.
 
 Once installed, you can run Exosphere using the `exosphere` command, like so:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -30,7 +30,7 @@ Installing from PyPI
 Exosphere is available on the `Python Package Index`_ (PyPI) for convenience,
 and can be installed using various methods.
 
-The package name is `exosphere-cli`.
+The package name is ``exosphere-cli``.
 
 .. admonition:: Note
 
@@ -66,8 +66,8 @@ The package name is `exosphere-cli`.
 
             uv tool install exosphere-cli
 
-        `uv tool` will handle downloading and installing the necessary Python
-        runtime and dependencies for you, and then make the `exosphere`
+        ``uv tool`` will handle downloading and installing the necessary Python
+        runtime and dependencies for you, and then make the ``exosphere``
         command available in your PATH.
 
 
@@ -84,7 +84,7 @@ Python runtime for you, if you do not have a suitable version available.
     with other Python packages and system versions of the libraries, and many
     distributions will in fact not allow you to install it that way.
 
-Once installed, you can run Exosphere using the `exosphere` command, like so:
+Once installed, you can run Exosphere using the ``exosphere`` command, like so:
 
 .. code-block:: bash
 
@@ -143,18 +143,18 @@ If you want the stable version, you can switch to the latest tag.
             git checkout |CurrentVersionTag|
 
         You can substitute |CurrentVersionTag| with a specific tag or
-        version to use a specific release, e.g., `v0.8.1`.
+        version to use a specific release, e.g., ``v2.4.1``.
 
         You can find the list of tags on the `GitHub releases page`_.
 
     .. group-tab:: Latest Development
 
         If you want the latest development version, you can switch to the
-        `main` branch. This is not recommended for most users, as it may
+        ``main`` branch. This is not recommended for most users, as it may
         contain unstable or untested code.
 
         If you want to hack on Exosphere, or get the latest features
-        even if they are not fully tested, you should use the `main` branch.
+        even if they are not fully tested, you should use the ``main`` branch.
 
         .. code-block:: bash
 
@@ -202,7 +202,7 @@ Exosphere directly:
             exosphere
 
 
-    From that point on, you can run Exosphere using the `exosphere` command.
+    From that point on, you can run Exosphere using the ``exosphere`` command.
 
 
 Updating Exosphere
@@ -244,7 +244,7 @@ From PyPI
 
     .. group-tab:: pipx
 
-        If you installed Exosphere using `pipx`, you can update it with:
+        If you installed Exosphere using ``pipx``, you can update it with:
 
         .. code-block:: bash
 
@@ -252,7 +252,7 @@ From PyPI
 
     .. group-tab:: uv
 
-        If you installed Exosphere using `uv`, you can update it with:
+        If you installed Exosphere using ``uv``, you can update it with:
 
         .. code-block:: bash
 
@@ -278,13 +278,13 @@ pulling the latest changes and then syncing with `uv`_:
             uv sync --no-dev
 
         You can substitute |CurrentVersionTag| with the latest tag or
-        specific version you want to use, e.g., `v0.8.1`.
+        specific version you want to use, e.g., ``v2.4.1``.
 
         You can find the list of tags on the `GitHub releases page`_.
 
     .. group-tab:: Latest Development
 
-        If you are on the `main` branch, you can update it with:
+        If you are on the ``main`` branch, you can update it with:
 
         .. code-block:: bash
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -54,11 +54,13 @@ The package name is `exosphere-cli`.
 
     .. group-tab:: uv
 
+        If you do not have Python 3.13 or later available, you can use **uv** to
+        install Exosphere.
+
         https://docs.astral.sh/uv/getting-started/installation/
 
-        If you do not have Python 3.13 or later available, you can use `uv`_ to
-        install Exosphere. Click the link above to see how to install `uv`_ for
-        your platform, and then simply run:
+        Click the link above to see how to install **uv** for your platform, and
+        then simply run:
 
         .. code-block:: bash
 

--- a/docs/source/providers.rst
+++ b/docs/source/providers.rst
@@ -11,7 +11,7 @@ below.
 Debian/Ubuntu (Apt)
 -------------------
 
-The Debian/Ubuntu provider is implemented in the `exosphere.providers.debian` module.
+The Debian/Ubuntu provider is implemented in the ``exosphere.providers.debian`` module.
 
 Repo sync **requires** sudo privileges, as it needs to run ``apt-get update`` to
 update the package cache from repository.
@@ -45,15 +45,15 @@ Exact Commands run on remote hosts
 Command dependencies
 ^^^^^^^^^^^^^^^^^^^^
 
-- `apt-get`
-- `grep`
+- ``apt-get``
+- ``grep``
 
 .. _Unattended Upgrades: https://wiki.debian.org/UnattendedUpgrades
 
 RedHat-Likes (Yum/DNF)
 ----------------------
 
-The RedHat provider is implemented in the `exosphere.providers.redhat` module.
+The RedHat provider is implemented in the ``exosphere.providers.redhat`` module.
 
 It implements the functionality identically between Yum and DNF, as they share
 an interface for the relevant commands. The only distinction is the command name.
@@ -95,11 +95,11 @@ Exact Commands run on remote systems
 Command dependencies
 ^^^^^^^^^^^^^^^^^^^^
 
-- `yum` or `dnf`
-- For updates (optional):
+- ``yum`` or ``dnf``
+- For pending reboot detection (optional):
 
-  - `python3-dnf-plugins-core` on dnf4 (installed by default on RHEL 8/9)
-  - `yum-utils` on yum
+  - ``python3-dnf-plugins-core`` on dnf4 (installed by default on RHEL 8/9)
+  - ``yum-utils`` on yum
 
 Usage Notes and Issues
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +113,7 @@ Some minor limitations:
   This is generally a misconfiguration, and you should seek vendor support to resolve this.
   Google Compute Platform (GCP) is known to exhibit this issue with some legacy vendor kernels.
 
-In some scenarios, the `yum` or `dnf` commands may hang when running due to
+In some scenarios, the ``yum`` or ``dnf`` commands may hang when running due to
 unexpectedly prompting for user input interactively, which Exosphere cannot handle.
 
 The provider is written to avoid this, but if you do encounter this, simply run
@@ -128,8 +128,8 @@ Note that we consider having to do this a bug, and would appreciate if you could
 FreeBSD (Pkg)
 -------------
 
-The FreeBSD provider is implemented in the `exosphere.providers.freebsd` module.
-It uses the `pkg` command to manage packages and updates.
+The FreeBSD provider is implemented in the ``exosphere.providers.freebsd`` module.
+It uses the ``pkg`` command to manage packages and updates.
 
 Repo sync **requires** sudo privileges, as it needs to run ``/usr/sbin/pkg update``
 to update the package cache from repository, as well as refresh ``vuln.xml`` for
@@ -160,23 +160,23 @@ Exact Commands run on remote systems
 
 - ``/usr/sbin/pkg update -q`` **(requires sudo)**
 - ``/usr/sbin/pkg audit -qF`` **(requires sudo)**
-- ``/usr/sbin/pkg audit -q`` for security updates
-- ``/usr/sbin/pkg upgrade -qn | grep -e '^\\s'``
+- ``pkg audit -q`` for security updates
+- ``pkg upgrade -qn | grep -e '^\s'``
 - ``freebsd-version -k``
 - ``freebsd-version -r``
 
 Command dependencies
 ^^^^^^^^^^^^^^^^^^^^
 
-- `pkg`
-- `grep`
-- `freebsd-version`
+- ``pkg``
+- ``grep``
+- ``freebsd-version``
 
 OpenBSD (pkg_add)
 -----------------
 
-The OpenBSD provider is implemented in the `exosphere.providers.openbsd` module.
-It uses the `pkg_add` command to manage packages and updates.
+The OpenBSD provider is implemented in the ``exosphere.providers.openbsd`` module.
+It uses the ``pkg_add`` command to manage packages and updates.
 
 Repo sync is essentially a no-op, as OpenBSD does not have a command to
 synchronize package repositories. The command being run will directly query
@@ -200,9 +200,9 @@ Limitations
 
 - On **stable/release**, all package updates are assumed to be security updates,
   since OpenBSD only ever updates packages for security issues.
-- If the system is tracking `-current` or `-beta`, security status will default to
+- If the system is tracking ``-current`` or ``-beta``, security status will default to
   False, as there is no way to tell given the rolling release nature of these branches.
-- On more exotic architectures, `syspatch` may not be available and the failure
+- On more exotic architectures, ``syspatch`` may not be available and the failure
   modes are untested. If you have such a system, and this breaks for you, please
   `file a bug report`_ and include the output of ``syspatch -l``.
 - Only handles binary packages, does not support ports or syspatch/system updates.
@@ -219,8 +219,8 @@ Exact Commands run on remote systems
 Command dependencies
 ^^^^^^^^^^^^^^^^^^^^
 
-- `pkg_add`
-- `grep`
-- `syspatch`
+- ``pkg_add``
+- ``grep``
+- ``syspatch``
 
 .. _file a bug report: https://github.com/mrdaemon/exosphere/issues

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,11 +10,11 @@ following this guide and adapting the simple scenario it presents to your needs.
 
     $ exosphere config paths
 
-Create ``config.yaml`` in the `Config` directory shown here.
+Create ``config.yaml`` in the ``Config`` directory shown here.
 
 .. tip::
 
-    You can also use `config.toml` or `config.json` if you prefer those formats.
+    You can also use ``config.toml`` or ``config.json`` if you prefer those formats.
     See the :doc:`configuration <configuration>` page for more details.
 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -73,8 +73,8 @@ You can also explore the interactive help system in the CLI by running:
 This will detect the platform and package manager for each host.
 It only needs to be done once, or if something changes on the host.
 
-If you encounter issues at this step, see the :doc:`connections`
-and :doc:`supportedos` pages for more details.
+If you encounter issues at this step, see the :doc:`connections <connections>`
+and :doc:`supported platforms <supportedos>` pages for more details.
 
 **Refresh Hosts**
 

--- a/docs/source/reporting.rst
+++ b/docs/source/reporting.rst
@@ -62,9 +62,9 @@ Below are examples of each output format to help you choose the right one for yo
 
     .. tab:: Markdown
 
-        Made available mostly as a lightweight intermediate format, since they can be
+        Made available mostly as a lightweight intermediate format, since it can be
         rendered to a variety of other formats while providing support for tables.
-        They can also be fed directly into any other tool that supports markdown.
+        It can also be fed directly into any other tool that supports markdown.
 
         .. literalinclude:: ../../examples/reports/full.md
             :language: markdown
@@ -185,7 +185,7 @@ All reports include:
 - **Update Details**: Package names, versions, and security status
 - **Metadata**: Report generation time and scope information
 
-The presentation and formatting varies by format, but the core information
+The presentation and formatting vary by format, but the core information
 remains consistent across all output types.
 
 .. tip::
@@ -259,7 +259,7 @@ and have a valid :doc:`package manager provider <providers>` assigned to them.
 
     Unless you are directly using the Python API (see :doc:`api/reporting`)
     to generate reports, you **can** safely assume that all the hosts in the
-    report have been discovered, and **will not** have `null` values anywhere
+    report have been discovered, and **will not** have ``null`` values anywhere
     other than ``last_refresh`` (if the host has never been refreshed).
 
 
@@ -282,7 +282,7 @@ Each host's ``updates`` array contains update objects with the following structu
 
     The ``current_version`` field may be ``null`` whenever the package is a new
     dependency. Interfaces in the Exosphere API usually translate this to the
-    string `(NEW)`, but the raw JSON will have ``null`` in these cases.
+    string ``(NEW)``, but the raw JSON will have ``null`` in these cases.
 
 .. literalinclude:: ../../examples/sample-report.json
    :language: json

--- a/docs/source/sudo.rst
+++ b/docs/source/sudo.rst
@@ -52,7 +52,7 @@ There are currently two valid settings for the Sudo Policy options:
 * ``skip``: Do not use sudo at all, skip operations that require it and emit a warning in logs
 * ``nopasswd``: Assume sudoers configuration allows running the provider commands without a password
 
-The default Sudo Policy for exosphere is `skip`, :ref:`configured globally <default_sudo_policy_option>`.
+The default Sudo Policy for Exosphere is ``skip``, :ref:`configured globally <default_sudo_policy_option>`.
 This means that Exosphere will not attempt to use sudo at all when running provider commands.
 
 This can also be configured per system, by setting the :ref:`sudo policy option <hosts_sudo_policy_option>`
@@ -146,10 +146,11 @@ On FreeBSD, you can set up a cron job or periodic task to run
 
 For other distributions, similar automated package management tools are available.
 
-How can I check what the effective Sudo Policy is for a given host?
--------------------------------------------------------------------
+Checking the Effective Sudo Policy
+----------------------------------
 
-You can use the ``sudo check`` helper command.
+To check what the effective Sudo Policy is for a given host, you can use the
+``sudo check`` helper command.
 
 As an example, to check the effective Sudo Policy for a host named ``bigserver``:
 

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -108,8 +108,8 @@ See below for more details.
 Some providers may require elevated privileges to perform certain operations, but this is
 entirely optional.
 
-More details about all of this are available in the :doc:`connections` and
-:doc:`sudo` sections.
+More details about all of this are available in the
+:doc:`connections <connections>` and :doc:`sudo <sudo>` sections.
 
 .. note::
 

--- a/docs/source/supportedos.rst
+++ b/docs/source/supportedos.rst
@@ -48,7 +48,7 @@ Compatibility List
   - OpenBSD (all supported versions)
   - *Package Managers*: ``pkg`` (FreeBSD), ``pkg_add`` (OpenBSD)
 
-.. admonition:: note
+.. admonition:: Note
 
    FreeBSD optionally requires the ``sudo`` package for repository sync operations.
    Unfortunately ``doas`` is not supported at this time.
@@ -58,7 +58,7 @@ Compatibility List
 
 - Other Linux distributions (e.g., Arch Linux, Gentoo, NixOS, etc.)
 - Other BSD systems (e.g. NetBSD)
-- Other Unix-like systems (e.g., Solaris, AIX, IRIX, Mac OS)
+- Other Unix-like systems (e.g., Solaris, AIX, IRIX, macOS)
 
 The bar for entry is fairly low to fit this description, as long as it can be connected
 to via SSH, has a POSIX shell available [#binsh]_ and returns something useful via
@@ -95,7 +95,7 @@ entirely through SSH connections and standard system utilities.
 
 **Optional Requirements**
 
-- **Elevated privileges** for certain operations on some platforms (i.e. `root`)
+- **Elevated privileges** for certain operations on some platforms (i.e. ``root``)
 - ``sudo`` installed on the remote host (if needed) and :doc:`configured properly <sudo>`
 
 See below for more details.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -126,7 +126,7 @@ or, for a single host:
 If a host fails, work through the checklist:
 
 * Your SSH agent is running and has the right key loaded
-* The username and port are correct (see :doc:`configuration`)
+* The username and port are correct (see the :doc:`configuration <configuration>` page)
 * The host is reachable and its SSH service is running
 * The host allows public key authentication
 

--- a/docs/source/ui.rst
+++ b/docs/source/ui.rst
@@ -175,8 +175,8 @@ allowing you to quickly see which hosts are online or offline at a glance.
 
 The following operations can be performed from the Dashboard:
 
-- **Ping All**: Press `shift+p` to ping all hosts and update their status.
-- **Discover All**: Press `ctrl+d` to discover all hosts and update their platform information.
+- **Ping All**: Press ``shift+p`` to ping all hosts and update their status.
+- **Discover All**: Press ``ctrl+d`` to discover all hosts and update their platform information.
 
 Inventory Screen
 ----------------
@@ -188,11 +188,11 @@ The Inventory screen provides a detailed view of all the hosts in your inventory
 
 The following operations can be performed from the Inventory screen:
 
-- **Refresh Updates**: Press `ctrl+r` to refresh the updates for all hosts.
-- **Sync & Refresh**: Press `ctrl+x` to sync the repositories and refresh updates
+- **Refresh Updates**: Press ``ctrl+r`` to refresh the updates for all hosts.
+- **Sync & Refresh**: Press ``ctrl+x`` to sync the repositories and refresh updates
   for all hosts.
-- **Filter**: Press `ctrl+f` to filter the hosts shown in the table.
-- **Sort**: Press `ctrl+s` to sort the table by a chosen column.
+- **Filter**: Press ``ctrl+f`` to filter the hosts shown in the table.
+- **Sort**: Press ``ctrl+s`` to sort the table by a chosen column.
 
 .. admonition:: Note
 
@@ -221,7 +221,7 @@ a security update.
 
 **Filtering Hosts**
 
-It is also possible to filter hosts with `ctrl+f`, which will open a prompt
+It is also possible to filter hosts with ``ctrl+f``, which will open a prompt
 with the available filters.
 
 .. image:: /_static/filter_sample.png
@@ -237,12 +237,12 @@ The active filter will be shown in the status bar at the bottom of the screen:
 .. image:: /_static/ui_inventory_statusbar.png
    :alt: Exosphere TUI Inventory Status Bar with Security Updates filter active
 
-You can clear the filter by pressing `ctrl+f` again and selecting the
+You can clear the filter by pressing ``ctrl+f`` again and selecting the
 "Show All" option.
 
 **Sorting Hosts**
 
-You can sort the hosts with `ctrl+s`, which opens a prompt listing the
+You can sort the hosts with ``ctrl+s``, which opens a prompt listing the
 sortable columns along with a *Reverse order* checkbox. Navigate the
 columns with the Arrow Keys, toggle reverse by pressing ``r`` (or focusing
 the checkbox with ``Tab`` and pressing ``Space``), and press ``Enter`` to
@@ -259,7 +259,7 @@ apply.
 
 After applying a sort, the active sort field and direction are shown in
 the status bar alongside any active filter. You can restore the original
-configuration order by pressing `ctrl+s` again and selecting the
+configuration order by pressing ``ctrl+s`` again and selecting the
 "Default (config order)" option (or pressing ``D``).
 
 .. image:: /_static/ui_inventory_sort_statusbar.png

--- a/src/exosphere/commands/config.py
+++ b/src/exosphere/commands/config.py
@@ -40,7 +40,7 @@ def show(
     Displays the current configuration options, or the value of a specific option
     if specified.
 
-    If `--full` is specified, it will show the entire configuration structure,
+    If ``--full`` is specified, it will show the entire configuration structure,
     including the inventory, beyond just the "options" section.
 
     Parameters
@@ -150,9 +150,9 @@ def diff(
     file can exclusively contain the options you want to change.
 
     This command allows you to see exactly what has been changed, optionally
-    in its context, using the `--full` option.
+    in its context, using the ``--full`` option.
 
-    For a full config dump, use the `show` command instead.
+    For a full config dump, use the ``show`` command instead.
 
     Parameters
     ----------

--- a/src/exosphere/commands/host.py
+++ b/src/exosphere/commands/host.py
@@ -270,7 +270,7 @@ def refresh(
     This command retrieves the host by name from the inventory
     and refreshes its state and available updates.
 
-    If `--sync` is specified, the package repositories will also be
+    If ``--sync`` is specified, the package repositories will also be
     synchronized remotely.
 
     Parameters

--- a/src/exosphere/commands/inventory.py
+++ b/src/exosphere/commands/inventory.py
@@ -122,11 +122,11 @@ def refresh(
     Connects to hosts in the inventory and retrieves pending package
     updates.
 
-    If `--discover` is specified, the platform information (Operating
+    If ``--discover`` is specified, the platform information (Operating
     System flavor, version, package manager) will also be refreshed.
     Also refreshes the online status in the process.
 
-    If `--sync` is specified, the package repositories will also be
+    If ``--sync`` is specified, the package repositories will also be
     synchronized remotely.
 
     Synchronizing the package repositories involves invoking whatever mechanism
@@ -135,7 +135,7 @@ def refresh(
     with a handful of slow hosts.
 
     By default, only the progress bar is shown during the operation.
-    If `--verbose` is specified, the name and completion status of each host
+    If ``--verbose`` is specified, the name and completion status of each host
     will be shown in real time.
 
     Parameters
@@ -342,18 +342,18 @@ def status(
     online status and whether or not the data is stale.
 
     Output can be filtered to show only hosts with pending updates
-    (`--updates-only`) or only those with pending security updates
-    (`--security-only`). These two filters are mutually exclusive.
+    (``--updates-only``) or only those with pending security updates
+    (``--security-only``). These two filters are mutually exclusive.
 
-    Output can also be sorted by any column with `--sort`, optionally
-    reversed with `--reverse`. Sorting by 'version' groups hosts by
+    Output can also be sorted by any column with ``--sort``, optionally
+    reversed with ``--reverse``. Sorting by 'version' groups hosts by
     flavor first, since versions are not comparable across flavors.
 
     When sorting by any column other than name, hosts with unknown
     or unsupported values for that column will be grouped together at the
     end.
 
-    Use `--full` to include extra columns, such as the host description.
+    Use ``--full`` to include extra columns, such as the host description.
 
     No matches when filtering will exit with code 3.
 
@@ -368,7 +368,7 @@ def status(
     sort
         Sort the table by the given column
     reverse
-        Reverse the sort order (requires `--sort`)
+        Reverse the sort order (requires ``--sort``)
     full
         Show additional columns, including host descriptions
     """

--- a/src/exosphere/commands/report.py
+++ b/src/exosphere/commands/report.py
@@ -102,8 +102,8 @@ def generate(
     the report will include all hosts in the inventory.
 
     It can further be narrowed to hosts with pending updates
-    (`--updates-only`) or pending security updates
-    (`--security-updates-only`), which are mutually exclusive.
+    (``--updates-only``) or pending security updates
+    (``--security-updates-only``), which are mutually exclusive.
 
     Note: Undiscovered or unsupported hosts are excluded from the report.
 
@@ -120,7 +120,7 @@ def generate(
     security_only
         Only report security updates
     tee
-        Also print report to stdout (requires `--output`)
+        Also print report to stdout (requires ``--output``)
     quiet
         Suppress informational messages
     navigation
@@ -241,14 +241,14 @@ def schema(
     Show or write the JSON Schema for the current version of Exosphere
 
     Emits the JSON Schema (draft-07) describing the structure produced
-    by `report generate --format json`, for the currently running
+    by ``report generate --format json``, for the currently running
     version of Exosphere.
 
     This allows anyone to easily get an overview of the structure,
     validate and integrate, offline, without a local source tree or
     access to the online documentation.
 
-    By default the schema is printed to stdout. Use `--output` to
+    By default the schema is printed to stdout. Use ``--output`` to
     write it to a file instead.
 
     Parameters


### PR DESCRIPTION
This PR contains a series of changes that felt through the cracks before the 3.0 release window closed.

It namely:

* Updates the README with details that appeared in 3.0
* Refreshes the docs index blurb to better line up with the README
* Cleans up multiple small structural/rendering nits
* Corrects multiple awkward sentences and instances of poor grammar
* Standardizes rendering of keywords and technical terms as string literals
* Documents the Cache lock file mechanisms added in 3.0
* Corrects an issue with the CLI Command Reference where anchor links were not correctly generated for subcommands sharing a name
* Improves the CSS for string literals, making them much nicer to look at
* Slightly indents subcommands under their parent command in the CLI reference, with a hairline rule, making the document much easier to parse visually.