### PR TITLE
Project: Change homepage and docs urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ dev = [
 ]
 
 [project.urls]
-homepage = "https://exosphere.readthedocs.io"
+homepage = "https://exosphere.tools"
+documentation = "https://docs.exosphere.tools"
 repository = "https://github.com/mrdaemon/exosphere"
 issues = "https://github.com/mrdaemon/exosphere/issues"
 


### PR DESCRIPTION
We now have a minisite at exosphere.tools, and the documentation has been re-homed under a cname at docs.exosphere.tools for consistency.